### PR TITLE
more CI quality checks using flake8/pep8, pylint, and codeql

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,8 +7,8 @@ ignore =
        # Whitespace round parameter '=' can be excessive
        #E252,
        # Multiple # in a comment is OK
-       E266,
-       E262,
+       #E266,
+       #E262,
        # Not excited by the "two blank lines" rule
        #E302,
        #E305,
@@ -19,6 +19,6 @@ ignore =
        # Lines ending with binary operators are OK
        #W504,
        # ignore missing debug import (only for pdb)
-       F401,
+       #F401,
 
 max-line-length = 84

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,24 @@
+[flake8]
+ignore =
+       # Prefer emacs indentation of continued lines
+       #E126,
+       #E127,
+       #E129,
+       # Whitespace round parameter '=' can be excessive
+       #E252,
+       # Multiple # in a comment is OK
+       E266,
+       E262,
+       # Not excited by the "two blank lines" rule
+       #E302,
+       #E305,
+       # or the one blank line rule
+       #E306,
+       # Ambigious variables are ok.
+       #E741,
+       # Lines ending with binary operators are OK
+       #W504,
+       # ignore missing debug import (only for pdb)
+       F401,
+
+max-line-length = 84

--- a/.gitchangelog.rc
+++ b/.gitchangelog.rc
@@ -1,0 +1,296 @@
+# -*- coding: utf-8; mode: python -*-
+##
+## Format
+##
+##   ACTION: [AUDIENCE:] COMMIT_MSG [!TAG ...]
+##
+## Description
+##
+##   ACTION is one of 'chg', 'fix', 'new'
+##
+##       Is WHAT the change is about.
+##
+##       'chg' is for refactor, small improvement, cosmetic changes...
+##       'fix' is for bug fixes
+##       'new' is for new features, big improvement
+##
+##   AUDIENCE is optional and one of 'dev', 'usr', 'pkg', 'test', 'doc'
+##
+##       Is WHO is concerned by the change.
+##
+##       'dev'  is for developpers (API changes, refactors...)
+##       'usr'  is for final users (UI changes)
+##       'pkg'  is for packagers   (packaging changes)
+##       'test' is for testers     (test only related changes)
+##       'doc'  is for doc guys    (doc only changes)
+##
+##   COMMIT_MSG is ... well ... the commit message itself.
+##
+##   TAGs are additionnal adjective as 'refactor' 'minor' 'cosmetic'
+##
+##       They are preceded with a '!' or a '@' (prefer the former, as the
+##       latter is wrongly interpreted in github.) Commonly used tags are:
+##
+##       'refactor' is obviously for refactoring code only
+##       'minor' is for a very meaningless change (a typo, adding a comment)
+##       'cosmetic' is for cosmetic driven change (re-indentation, 80-col...)
+##       'wip' is for partial functionality but complete subfunctionality.
+##
+## Example:
+##
+##   new: usr: support of bazaar implemented
+##   chg: re-indentend some lines !cosmetic
+##   new: dev: updated code to be compatible with last version of killer lib.
+##   fix: pkg: updated year of licence coverage.
+##   new: test: added a bunch of test around user usability of feature X.
+##   fix: typo in spelling my name in comment. !minor
+##
+##   Please note that multi-line commit message are supported, and only the
+##   first line will be considered as the "summary" of the commit message. So
+##   tags, and other rules only applies to the summary.  The body of the commit
+##   message will be displayed in the changelog without reformatting.
+
+
+##
+## ``ignore_regexps`` is a line of regexps
+##
+## Any commit having its full commit message matching any regexp listed here
+## will be ignored and won't be reported in the changelog.
+##
+ignore_regexps = [
+    r'@minor', r'!minor',
+    r'@cosmetic', r'!cosmetic',
+    r'@refactor', r'!refactor',
+    r'@wip', r'!wip',
+    r'^([cC]hg|[fF]ix|[nN]ew)\s*:\s*[p|P]kg:',
+    r'^([cC]hg|[fF]ix|[nN]ew)\s*:\s*[d|D]ev:',
+    r'^(.{3,3}\s*:)?\s*[fF]irst commit.?\s*$',
+    r'^$',  ## ignore commits with empty messages
+]
+
+
+## ``section_regexps`` is a list of 2-tuples associating a string label and a
+## list of regexp
+##
+## Commit messages will be classified in sections thanks to this. Section
+## titles are the label, and a commit is classified under this section if any
+## of the regexps associated is matching.
+##
+## Please note that ``section_regexps`` will only classify commits and won't
+## make any changes to the contents. So you'll probably want to go check
+## ``subject_process`` (or ``body_process``) to do some changes to the subject,
+## whenever you are tweaking this variable.
+##
+section_regexps = [
+    ('New', [
+        r'^[nN]ew\s*:\s*((dev|use?r|pkg|test|doc)\s*:\s*)?([^\n]*)$',
+     ]),
+    ('Features', [
+       r'^([nN]ew|[fF]eat)\s*:\s*((dev|use?r|pkg|test|doc)\s*:\s*)?([^\n]*)$',
+     ]),
+    ('Changes', [
+        r'^[cC]hg\s*:\s*((dev|use?r|pkg|test|doc)\s*:\s*)?([^\n]*)$',
+     ]),
+    ('Fixes', [
+        r'^[fF]ix\s*:\s*((dev|use?r|pkg|test|doc)\s*:\s*)?([^\n]*)$',
+     ]),
+
+    ('Other', None ## Match all lines
+     ),
+]
+
+
+## ``body_process`` is a callable
+##
+## This callable will be given the original body and result will
+## be used in the changelog.
+##
+## Available constructs are:
+##
+##   - any python callable that take one txt argument and return txt argument.
+##
+##   - ReSub(pattern, replacement): will apply regexp substitution.
+##
+##   - Indent(chars="  "): will indent the text with the prefix
+##     Please remember that template engines gets also to modify the text and
+##     will usually indent themselves the text if needed.
+##
+##   - Wrap(regexp=r"\n\n"): re-wrap text in separate paragraph to fill 80-Columns
+##
+##   - noop: do nothing
+##
+##   - ucfirst: ensure the first letter is uppercase.
+##     (usually used in the ``subject_process`` pipeline)
+##
+##   - final_dot: ensure text finishes with a dot
+##     (usually used in the ``subject_process`` pipeline)
+##
+##   - strip: remove any spaces before or after the content of the string
+##
+##   - SetIfEmpty(msg="No commit message."): will set the text to
+##     whatever given ``msg`` if the current text is empty.
+##
+## Additionally, you can `pipe` the provided filters, for instance:
+#body_process = Wrap(regexp=r'\n(?=\w+\s*:)') | Indent(chars="  ")
+#body_process = Wrap(regexp=r'\n(?=\w+\s*:)')
+#body_process = noop
+#body_process = ReSub(r'((^|\n)[A-Z]\w+(-\w+)*: .*(\n\s+.*)*)+$', r'') | strip
+#body_process = lambda text: ""
+body_process = ReSub(r'.*', '')
+
+## ``subject_process`` is a callable
+##
+## This callable will be given the original subject and result will
+## be used in the changelog.
+##
+## Available constructs are those listed in ``body_process`` doc.
+subject_process = (strip |
+    ReSub(r'^([cC]hg|[fF]ix|[nN]ew)\s*:\s*((dev|use?r|pkg|test|doc)\s*:\s*)?([^\n@]*)(@[a-z]+\s+)*$', r'\4') |
+    SetIfEmpty("No commit message.") | ucfirst | final_dot)
+
+
+## ``tag_filter_regexp`` is a regexp
+##
+## Tags that will be used for the changelog must match this regexp.
+##
+#tag_filter_regexp = r'^v?[0-9]+\.[0-9]+(\.[0-9]+)?$'
+tag_filter_regexp = r'^[0-9]+\.[0-9]+(\.[0-9]+)?$'
+
+
+## ``unreleased_version_label`` is a string or a callable that outputs a string
+##
+## This label will be used as the changelog Title of the last set of changes
+## between last valid tag and HEAD if any.
+#unreleased_version_label = "(unreleased)"
+unreleased_version_label = lambda: swrap(
+    ["git", "describe", "--tags"],
+shell=False)
+
+
+## ``output_engine`` is a callable
+##
+## This will change the output format of the generated changelog file
+##
+## Available choices are:
+##
+##   - rest_py
+##
+##        Legacy pure python engine, outputs ReSTructured text.
+##        This is the default.
+##
+##   - mustache(<template_name>)
+##
+##        Template name could be any of the available templates in
+##        ``templates/mustache/*.tpl``.
+##        Requires python package ``pystache``.
+##        Examples:
+##           - mustache("markdown")
+##           - mustache("restructuredtext")
+##
+##   - makotemplate(<template_name>)
+##
+##        Template name could be any of the available templates in
+##        ``templates/mako/*.tpl``.
+##        Requires python package ``mako``.
+##        Examples:
+##           - makotemplate("restructuredtext")
+##
+#output_engine = rest_py
+#output_engine = mustache("restructuredtext")
+output_engine = mustache("markdown")
+#output_engine = makotemplate("restructuredtext")
+
+
+## ``include_merge`` is a boolean
+##
+## This option tells git-log whether to include merge commits in the log.
+## The default is to include them.
+include_merge = True
+
+
+## ``log_encoding`` is a string identifier
+##
+## This option tells gitchangelog what encoding is outputed by ``git log``.
+## The default is to be clever about it: it checks ``git config`` for
+## ``i18n.logOutputEncoding``, and if not found will default to git's own
+## default: ``utf-8``.
+#log_encoding = 'utf-8'
+
+
+## ``publish`` is a callable
+##
+## Sets what ``gitchangelog`` should do with the output generated by
+## the output engine. ``publish`` is a callable taking one argument
+## that is an interator on lines from the output engine.
+##
+## Some helper callable are provided:
+##
+## Available choices are:
+##
+##   - stdout
+##
+##        Outputs directly to standard output
+##        (This is the default)
+##
+##   - FileInsertAtFirstRegexMatch(file, pattern, idx=lamda m: m.start(), flags)
+##
+##        Creates a callable that will parse given file for the given
+##        regex pattern and will insert the output in the file.
+##        ``idx`` is a callable that receive the matching object and
+##        must return a integer index point where to insert the
+##        the output in the file. Default is to return the position of
+##        the start of the matched string.
+##
+##   - FileRegexSubst(file, pattern, replace, flags)
+##
+##        Apply a replace inplace in the given file. Your regex pattern must
+##        take care of everything and might be more complex. Check the README
+##        for a complete copy-pastable example.
+##
+# publish = FileInsertIntoFirstRegexMatch(
+#     "CHANGELOG.rst",
+#     r'/(?P<rev>[0-9]+\.[0-9]+(\.[0-9]+)?)\s+\([0-9]+-[0-9]{2}-[0-9]{2}\)\n--+\n/',
+#     idx=lambda m: m.start(1)
+# )
+#publish = stdout
+
+
+## ``revs`` is a list of callable or a list of string
+##
+## callable will be called to resolve as strings and allow dynamical
+## computation of these. The result will be used as revisions for
+## gitchangelog (as if directly stated on the command line). This allows
+## to filter exaclty which commits will be read by gitchangelog.
+##
+## To get a full documentation on the format of these strings, please
+## refer to the ``git rev-list`` arguments. There are many examples.
+##
+## Using callables is especially useful, for instance, if you
+## are using gitchangelog to generate incrementally your changelog.
+##
+## Some helpers are provided, you can use them::
+##
+##   - FileFirstRegexMatch(file, pattern): will return a callable that will
+##     return the first string match for the given pattern in the given file.
+##     If you use named sub-patterns in your regex pattern, it'll output only
+##     the string matching the regex pattern named "rev".
+##
+##   - Caret(rev): will return the rev prefixed by a "^", which is a
+##     way to remove the given revision and all its ancestor.
+##
+## Please note that if you provide a rev-list on the command line, it'll
+## replace this value (which will then be ignored).
+##
+## If empty, then ``gitchangelog`` will act as it had to generate a full
+## changelog.
+##
+## The default is to use all commits to make the changelog.
+#revs = ["^1.0.3", ]
+#revs = [
+#    Caret(
+#        FileFirstRegexMatch(
+#            "CHANGELOG.rst",
+#            r"(?P<rev>[0-9]+\.[0-9]+(\.[0-9]+)?)\s+\([0-9]+-[0-9]{2}-[0-9]{2}\)\n--+\n")),
+#    "HEAD"
+#]
+revs = []

--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -1,0 +1,21 @@
+name: Security check - Bandit
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "*" ]
+  pull_request:
+    branches: [ "*" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Run bandit
+      uses: ioggstream/bandit-report-artifacts@v0.0.2
+      with:
+        project_path: redis_ipc.py
+        ignore_failure: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,59 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+#  schedule:
+#    - cron: '21 20 * * 5'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-18.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'cpp', 'python']
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      if: matrix.language == 'python'
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+
+    - name: Install python deps
+      if: matrix.language == 'python'
+      run: |
+        python -m pip install --upgrade pip
+        pip install redis
+        # Set the `CODEQL-PYTHON` environment variable to the Python executable
+        # that includes the dependencies
+        echo "CODEQL_PYTHON=$(which python)" >> $GITHUB_ENV
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        queries: +security-and-quality
+        languages: ${{ matrix.language }}
+        setup-python-dependencies: false
+
+    - name: Install dependencies
+      if: matrix.language == 'cpp'
+      run: |
+        sudo apt-get -qq update
+        sudo apt-get install -y libhiredis-dev autoconf automake
+        sudo apt-get install -y libjson-c-dev
+
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,13 +10,13 @@ on:
 
 jobs:
   analyze:
-    name: Analyze
+    name: Analyze C++
     runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'cpp', 'python']
+        language: [ 'cpp']
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
 
     steps:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,0 +1,32 @@
+name: Pylint
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: [ master ]
+
+jobs:
+  pylint:
+
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install tox
+      run: |
+        python -m pip install --upgrade pip wheel
+        pip install tox tox-gh-actions
+    
+    - name: Run pylint
+      run: |
+        tox -e lint

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -99,9 +99,16 @@ jobs:
       with:
         fetch-depth: 0
 
-    - uses: sarnold/cccc-action@main
+    - uses: sarnold/cccc-action@0.2
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN}}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        file_extensions: |
+          .hh
+          .h
+          .c
+        source_dirs: |
+          src
+          inc
 
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Message bus
       run: |
         mkdir -p /tmp/redis-ipc
-        redis-server --port 0 --pidfile /run/redis.pid --unixsocket /tmp/redis-ipc/socket --unixsocketperm 600 &
+        redis-server --port 0 --pidfile /tmp/redis.pid --unixsocket /tmp/redis-ipc/socket --unixsocketperm 600 &
 
     - name: Test
       run: |
@@ -84,7 +84,7 @@ jobs:
 
     - name: Cleanup
       run: |
-        killall redis-server
+        cat /tmp/redis.pid | xargs kill
 
     - uses: codecov/codecov-action@v2
       with:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -99,13 +99,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - uses: sarnold/cccc-action@0.2
+    - uses: sarnold/cccc-action@main
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        file_extensions: |
-          .hh
-          .h
-          .c
+        target_branch: gh-pages
         source_dirs: |
           src
           inc

--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,0 +1,17 @@
+scanner:
+    linter: flake8  # Other option is pycodestyle
+
+no_blank_comment: False  # If True, no comment is made on PR without any errors.
+descending_issues_order: True  # If True, PEP 8 issues in message will be displayed in descending order of line numbers in the file
+
+[flake8]
+exclude =
+    .git,
+    .github,
+    __pycache__,
+    build,
+    dist,
+    src,
+    inc,
+
+max-line-length = 84  # match .flake8 cfg file

--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,4 +1,5 @@
 scanner:
+    diff_only: True
     linter: flake8  # Other option is pycodestyle
 
 no_blank_comment: False  # If True, no comment is made on PR without any errors.

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,9 @@
 ===========
  redis-ipc
 ===========
-|ci| |codeql| |bandit| |cov|
+|ci| |codeql| |pylint|
+
+|bandit| |cov|
 
 |std| |python| |style|
 
@@ -551,6 +553,10 @@ When finished with the above, don't forget to kill the redis server::
 .. |codeql| image:: https://github.com/VCTLabs/redis-ipc/actions/workflows/codeql.yml/badge.svg
     :target: https://github.com/VCTLabs/redis-ipc/actions/workflows/codeql.yml
     :alt: GitHub CI CodeQL Status
+
+.. |pylint| image:: https://github.com/VCTLabs/redis-ipc/actions/workflows/pylint.yml/badge.svg
+    :target: https://github.com/VCTLabs/redis-ipc/actions/workflows/pylint.yml
+    :alt: GitHub CI Pyliint Status
 
 .. |cov| image:: https://img.shields.io/codecov/c/github/VCTLabs/redis-ipc
     :target: https://codecov.io/gh/VCTLabs/redis-ipc

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,11 @@
 ===========
  redis-ipc
 ===========
-|ci| |codeql| |cov|
+|ci| |codeql| |bandit| |cov|
 
-|license| |python| |tag|
+|std| |python| |style|
+
+|tag| |license|
 
 redis-ipc is an example of how redis_ can be used as an advanced IPC 
 mechanism on an embedded Linux system, for instance as a substitute for the
@@ -554,6 +556,10 @@ When finished with the above, don't forget to kill the redis server::
     :target: https://codecov.io/gh/VCTLabs/redis-ipc
     :alt: Codecov test coverage
 
+.. |bandit| image:: https://github.com/VCTLabs/redis-ipc/actions/workflows/bandit.yml/badge.svg
+    :target: https://github.com/VCTLabs/redis-ipc/actions/workflows/bandit.yml
+    :alt: Security check - Bandit
+
 .. |license| image:: https://badges.frapsoft.com/os/gpl/gpl.png?v=103
     :target: https://opensource.org/licenses/GPL-2.0/
     :alt: License
@@ -565,3 +571,11 @@ When finished with the above, don't forget to kill the redis server::
 .. |python| image:: https://img.shields.io/badge/python-3.6+-blue.svg
     :target: https://www.python.org/downloads/
     :alt: Python
+
+.. |style| image:: https://img.shields.io/badge/Py%20code%20style-pylint-00000.svg
+    :target: https://github.com/pycqa/pylint/
+    :alt: Python Style
+
+.. |std| image:: https://img.shields.io/badge/Standards-C++11%20%20C99-00000.svg
+    :target: https://isocpp.org/wiki/faq/cpp11
+    :alt: Other standards

--- a/README.rst
+++ b/README.rst
@@ -1,23 +1,9 @@
 ===========
  redis-ipc
 ===========
+|ci| |codeql| |cov|
 
-.. image:: https://badges.frapsoft.com/os/gpl/gpl.png?v=103
-    :target: https://opensource.org/licenses/GPL-2.0/
-    :alt: License
-
-.. image:: https://img.shields.io/github/v/tag/VCTLabs/redis-ipc?color=green&include_prereleases&label=latest%20release
-    :target: https://github.com/VCTLabs/redis-ipc/releases
-    :alt: GitHub tag (latest SemVer, including pre-release)
-
-.. image:: https://github.com/VCTLabs/redis-ipc/actions/workflows/smoke.yml/badge.svg
-    :target: https://github.com/VCTLabs/redis-ipc/actions/workflows/smoke.yml
-    :alt: GitHub CI Workflow Status
-
-.. image:: https://img.shields.io/codecov/c/github/VCTLabs/redis-ipc
-    :target: https://codecov.io/gh/VCTLabs/redis-ipc
-    :alt: Codecov test coverage
-
+|tag| |license|
 
 redis-ipc is an example of how redis_ can be used as an advanced IPC 
 mechanism on an embedded Linux system, for instance as a substitute for the
@@ -555,3 +541,23 @@ When finished with the above, don't forget to kill the redis server::
 .. _json-c: https://github.com/json-c/json-c/wiki
 .. _EPEL: https://fedoraproject.org/wiki/EPEL
 .. _JSON objects: https://en.wikipedia.org/wiki/Json
+
+.. |ci| image:: https://github.com/VCTLabs/redis-ipc/actions/workflows/smoke.yml/badge.svg
+    :target: https://github.com/VCTLabs/redis-ipc/actions/workflows/smoke.yml
+    :alt: GitHub CI Smoke Test Status
+
+.. |codeql| image:: https://github.com/VCTLabs/redis-ipc/actions/workflows/codeql.yml/badge.svg
+    :target: https://github.com/VCTLabs/redis-ipc/actions/workflows/codeql.yml
+    :alt: GitHub CI CodeQL Status
+
+.. |cov| image:: https://img.shields.io/codecov/c/github/VCTLabs/redis-ipc
+    :target: https://codecov.io/gh/VCTLabs/redis-ipc
+    :alt: Codecov test coverage
+
+.. |license| image:: https://badges.frapsoft.com/os/gpl/gpl.png?v=103
+    :target: https://opensource.org/licenses/GPL-2.0/
+    :alt: License
+
+.. |tag| image:: https://img.shields.io/github/v/tag/VCTLabs/redis-ipc?color=green&include_prereleases&label=latest%20release
+    :target: https://github.com/VCTLabs/redis-ipc/releases
+    :alt: GitHub tag (latest SemVer, including pre-release)

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
 ===========
 |ci| |codeql| |cov|
 
-|tag| |license|
+|license| |python| |tag|
 
 redis-ipc is an example of how redis_ can be used as an advanced IPC 
 mechanism on an embedded Linux system, for instance as a substitute for the
@@ -561,3 +561,7 @@ When finished with the above, don't forget to kill the redis server::
 .. |tag| image:: https://img.shields.io/github/v/tag/VCTLabs/redis-ipc?color=green&include_prereleases&label=latest%20release
     :target: https://github.com/VCTLabs/redis-ipc/releases
     :alt: GitHub tag (latest SemVer, including pre-release)
+
+.. |python| image:: https://img.shields.io/badge/python-3.6+-blue.svg
+    :target: https://www.python.org/downloads/
+    :alt: Python

--- a/autogen.sh
+++ b/autogen.sh
@@ -23,7 +23,7 @@ autoconf || abort "autoconf"
 
 if test -z "$*"; then
         echo "You still need to run ./configure - if you wish to pass any arguments"
-        echo "to it, please specify them on the $0 command line."
+        echo "to it, please specify them on the configure command line."
 fi
 
 #set +x

--- a/redis_ipc.py
+++ b/redis_ipc.py
@@ -46,7 +46,8 @@ def jdic2pdic(jdic):
     return pd
 
 
-def redis_connect(unix_socket_path="/tmp/redis-ipc/socket"):
+# default /tmp path is only used in a trusted/isolated test environment
+def redis_connect(unix_socket_path="/tmp/redis-ipc/socket"):  # nosec
     """
     attempt to open a connection to the Redis server
     raise an exception if this does not work

--- a/redis_ipc.py
+++ b/redis_ipc.py
@@ -1,12 +1,14 @@
-# This is a Python module to provide client access to the Redis server
-# it is treated as a library
+""""
+This is a Python module to provide client access to the Redis server.
+"""
 
 import os
-import redis
-import json
 import time
-import pdb  ## required for debug  (no kidding)
+import json
+import redis
 
+# instead of global pdb import, add this where you want to start debugger:
+# import pdb; pdb.set_trace()
 
 # global data
 """
@@ -18,14 +20,14 @@ def pdic2jdic(pdic):
     """
     pdic   -    a Python dictionary
 
-    returns a JSON dictionary
+    returns a JSON string
     """
     if not isinstance(pdic, dict):
         raise NotDict
     try:
         jd = json.dumps(pdic)
     except (TypeError, ValueError):
-        raise BadMessage
+        raise BadMessage from None
     return jd
 
 
@@ -38,7 +40,7 @@ def jdic2pdic(jdic):
     try:
         pd = json.loads(jdic)
     except (TypeError, ValueError):
-        raise BadMessage
+        raise BadMessage from None
     if not isinstance(pd, dict):
         raise NotDict
     return pd
@@ -53,7 +55,7 @@ def redis_connect(unix_socket_path="/tmp/redis-ipc/socket"):
     try:
         conn = redis.StrictRedis(unix_socket_path=unix_socket_path)
     except redis.ConnectionError:
-        raise NoRedis
+        raise NoRedis from None
     return conn
 
 
@@ -69,16 +71,17 @@ MsgTimeout = RedisIpcExc("redis message request timed out")
 
 
 # the main feature here is a class which will provide the wanted access
-class redis_client(object):
+class RedisClient():
+    """
+    component : friendly name for calling program
+                (e.g. how it is labeled on system architecture diagrams
+                 as opposed to exact executable name)
+    thread: friendly name for specific thread of execution,
+            allowing IPC from multiple threads in a multi-threaded program
+    """
+
     def __init__(self, component, thread="main"):
-        """
-        component : friendly name for calling program
-                    (e.g. how it is labeled on system architecture diagrams
-                     as opposed to exact executable name)
-        thread: friendly name for specific thread of execution,
-                allowing IPC from multiple threads in a multi-threaded program
-        """
-        global redis_connect
+        # global redis_connect
         self.component = component
         self.thread = thread
 
@@ -171,15 +174,15 @@ class redis_client(object):
             return decoded_reply  # good enough
 
 
-class redis_server(object):
+class RedisServer():
+    """
+    component : friendly name for calling program
+                (e.g. how it is labeled on system architecture diagrams
+                 as opposed to exact executable name)
+    """
 
     def __init__(self, component):
-        """
-        component : friendly name for calling program
-                    (e.g. how it is labeled on system architecture diagrams
-                     as opposed to exact executable name)
-        """
-        global redis_connect
+        # global redis_connect
         self.component = component
 
         # process number of this component (a python program)

--- a/redis_ipc.py
+++ b/redis_ipc.py
@@ -5,39 +5,44 @@ import os
 import redis
 import json
 import time
-import pdb   ########## debug  ( no kidding)
+import pdb  ## required for debug  (no kidding)
+
+
 # global data
 """
 """
+
 
 # global functions
 def pdic2jdic(pdic):
     """
     pdic   -    a Python dictionary
-    
+
     returns a JSON dictionary
     """
-    if type(pdic) != type({}):
+    if not isinstance(pdic, dict):
         raise NotDict
     try:
-        jd=json.dumps(pdic)
-    except (TypeError,ValueError):
+        jd = json.dumps(pdic)
+    except (TypeError, ValueError):
         raise BadMessage
     return jd
-    
+
+
 def jdic2pdic(jdic):
     """
     jdic     -    a JSON string which is a hash
-    
+
     returns a Python dictionary
     """
     try:
-        pd=json.loads(jdic)
-    except (TypeError,ValueError):
+        pd = json.loads(jdic)
+    except (TypeError, ValueError):
         raise BadMessage
-    if type(pd) != type({}):
+    if not isinstance(pd, dict):
         raise NotDict
     return pd
+
 
 def redis_connect(unix_socket_path="/tmp/redis-ipc/socket"):
     """
@@ -46,22 +51,26 @@ def redis_connect(unix_socket_path="/tmp/redis-ipc/socket"):
     return the connection object if it does work
     """
     try:
-        conn=redis.StrictRedis(unix_socket_path=unix_socket_path)
+        conn = redis.StrictRedis(unix_socket_path=unix_socket_path)
     except redis.ConnectionError:
         raise NoRedis
     return conn
-    
+
+
 # exceptions
 class RedisIpcExc(Exception):
     pass
-NoRedis     =  RedisIpcExc("redis server not available")
-NotDict     =  RedisIpcExc("redis message was not a Python dictionary")
-BadMessage  =  RedisIpcExc("redis message not a recognizable message")
-MsgTimeout  =  RedisIpcExc("redis message request timed out")
+
+
+NoRedis = RedisIpcExc("redis server not available")
+NotDict = RedisIpcExc("redis message was not a Python dictionary")
+BadMessage = RedisIpcExc("redis message not a recognizable message")
+MsgTimeout = RedisIpcExc("redis message request timed out")
+
 
 # the main feature here is a class which will provide the wanted access
 class redis_client(object):
-    def __init__(self,component,thread="main"):
+    def __init__(self, component, thread="main"):
         """
         component : friendly name for calling program
                     (e.g. how it is labeled on system architecture diagrams
@@ -70,25 +79,25 @@ class redis_client(object):
                 allowing IPC from multiple threads in a multi-threaded program
         """
         global redis_connect
-        self.component=component
-        self.thread=thread
+        self.component = component
+        self.thread = thread
 
         # process number of this component (a python program)
-        self.process_number=os.getpid()
+        self.process_number = os.getpid()
 
         # construct name of queue where replies to commands should arrive
         self.results_queue = "queues.results.%s.%s" % (component, thread)
 
         # initialize redis connection
-        self.redis_conn=redis_connect()
+        self.redis_conn = redis_connect()
 
     def __generate_msg_id(self):
         # unique id for message
         # component name, process number, timestamp
-        ts=str(time.time())   # floating timestamp
-        the_id=self.component + ':' + str(self.process_number) + ':' + ts
-        return the_id,ts
-        
+        ts = str(time.time())   # floating timestamp
+        the_id = self.component + ':' + str(self.process_number) + ':' + ts
+        return the_id, ts
+
     def redis_ipc_send_and_receive(self, dest, cmd, tmout):
         """
         dest     -   name of the component to handle this command (string)
@@ -96,7 +105,7 @@ class redis_client(object):
         tmout    -   timeout for receiving a response, floating seconds
         """
         # add standard fields to the command dictionary
-        late_news=self.__generate_msg_id()  # id and timestamp
+        late_news = self.__generate_msg_id()  # id and timestamp
         cmd["timestamp"] = late_news[1]  # just the timestamp
         cmd["component"] = self.component
         cmd["thread"] = self.thread
@@ -112,58 +121,58 @@ class redis_client(object):
 
         # wait on results queue for the answer
         # an exception is raised by the request function if it times out
-        response=self.__redis_ipc_receive_reply(cmd, tmout)
+        response = self.__redis_ipc_receive_reply(cmd, tmout)
         return response
-        
+
     def __redis_ipc_send_command(self, dest_queue, cmd):
         """
         arguments are mandatory
-        dest_queue -   command queue serviced by destination component 
+        dest_queue -   command queue serviced by destination component
         cmd        -   a command known to the receiving component
-                     
+
         this routine does not block
         it just sends the command to the back of the queue
         """
         # turn command into a JSON dictionary before sending it
-        msg=pdic2jdic(cmd)
+        msg = pdic2jdic(cmd)
 
         # send it via Redis
-        self.redis_conn.rpush(dest_queue,msg)  # no waiting
+        self.redis_conn.rpush(dest_queue, msg)  # no waiting
 
     def __redis_ipc_receive_reply(self, cmd, tmout):
         """
         arguments are mandatory
         cmd           - command for which we await a reply
         tmout         - timeout for receiving a response, floating seconds
-        
+
         a proper response is a JSON dictionary
         turn it into a Python dictionary
-        
-        if the request timed out, the response is empty, 
+
+        if the request timed out, the response is empty,
         and an exception will be raised
         if a non-empty value was received, if it is not the response
         to the specified command
            try again
-        else 
+        else
            return this result
-        
+
         """
-        
+
         # use self.results_queue as name of queue to wait on
         # throw out received messages until reply["command_id"] == cmd["command_id"]
         while True:
-            redis_reply=self.redis_conn.blpop(self.results_queue, tmout)
-            if redis_reply==None:
+            redis_reply = self.redis_conn.blpop(self.results_queue, tmout)
+            if redis_reply is None:
                 raise MsgTimeout
-            decoded_reply=jdic2pdic(redis_reply[1])
+            decoded_reply = jdic2pdic(redis_reply[1])
             if decoded_reply["command_id"] != cmd["command_id"]:
                 continue  # skip this message, not our response
             # take it
             return decoded_reply  # good enough
-            
-            
+
+
 class redis_server(object):
-    
+
     def __init__(self, component):
         """
         component : friendly name for calling program
@@ -171,33 +180,33 @@ class redis_server(object):
                      as opposed to exact executable name)
         """
         global redis_connect
-        self.component=component
+        self.component = component
 
         # process number of this component (a python program)
-        self.process_number=os.getpid()
+        self.process_number = os.getpid()
 
         # construct name of queue where commands should arrive
         self.command_queue = "queues.commands.%s" % component
 
         # initialize redis connection
-        self.redis_conn=redis_connect()
+        self.redis_conn = redis_connect()
 
     def redis_ipc_receive_command(self):
         """
-        blocks for command to arrive in own command queue, 
+        blocks for command to arrive in own command queue,
         return it as Python dictionary
         """
         # get serialized command message
-        redis_reply=self.redis_conn.blpop(self.command_queue)
-        decoded_reply=jdic2pdic(redis_reply[1])
+        redis_reply = self.redis_conn.blpop(self.command_queue)
+        decoded_reply = jdic2pdic(redis_reply[1])
         return decoded_reply
-        
+
     def redis_ipc_send_reply(self, cmd, result):
         """
         arguments are mandatory
         cmd    - command that was processed so result is now available
         result - the generated result
-                     
+
         this routine does not block
         it just sends the reply to the back of the queue
         """
@@ -209,7 +218,7 @@ class redis_server(object):
         result["command_id"] = cmd["command_id"]
 
         # turn command into a JSON dictionary before sending it
-        msg=pdic2jdic(result)
+        msg = pdic2jdic(result)
 
         # send it via Redis
         self.redis_conn.rpush(dest_queue, msg)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,49 @@
+[tox]
+envlist = py3{6,7,8,9}-linux
+skip_missing_interpreters = true
+isolated_build = true
+skipsdist=True
+
+[gh-actions]
+python =
+    3.6: py36
+    3.7: py37
+    3.8: py38
+    3.9: py39
+
+[gh-actions:env]
+PLATFORM =
+    ubuntu-20.04: linux
+
+[testenv]
+passenv =
+    pythonLocation
+    CI
+    OS
+    PYTHONIOENCODING
+
+setenv =
+  PYTHONPATH={toxinidir}
+
+deps =
+    pip>=20.0.1
+    redis
+    #nose
+    #nosexcover
+
+commands =
+    python -c "import redis_ipc"
+    python -m doctest -v README.rst
+
+[testenv:lint]
+passenv =
+    CI
+    PYTHONIOENCODING
+
+deps =
+    pip>=20.0.1
+    redis
+    pylint
+
+commands =
+    pylint --fail-under=9 redis_ipc.py

--- a/tox.ini
+++ b/tox.ini
@@ -46,4 +46,4 @@ deps =
     pylint
 
 commands =
-    pylint --fail-under=9 redis_ipc.py
+    pylint --fail-under=9.25 redis_ipc.py


### PR DESCRIPTION
* flake8/pylint code cleanup in redis_ipc python module
* codeql, bandit, and pylint workflows with status badges
* pep8speaks PR bot, bandit annotations, tox cfg for python
* added modified gitchangelog.rc release cfg
*  readme updates for python module and badges

Note: codeql python scan disabled (didn't find anything and took 5-6 mins) and replaced with bandit.