### PR TITLE
configurable path to redis server socket

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -135,6 +135,22 @@ jobs:
       with:
         python-version: '3.9'
 
+    - name: Set platform server (socket) dir
+      id: set_temp_dirs
+      run: |
+        MKTEMP=$(mktemp -d)
+        echo "Platform temp dir is: ${MKTEMP}"
+        echo "GH CI temp dir is: ${RUNNER_TEMP}"
+        if [ "${ImageOS}" != "ubuntu18" ]
+        then
+            TEMP_DIR="${MKTEMP}"
+        else
+            TEMP_DIR="${RUNNER_TEMP}"
+        fi
+        echo "Setting runtime dir: ${TEMP_DIR}"
+        echo "TEMP_DIR=${TEMP_DIR}" >> $GITHUB_ENV
+        bash -c set
+
     - name: Install deps plus redis
       run: |
         sudo apt-get -qq update
@@ -148,14 +164,34 @@ jobs:
     - name: Add python requirements
       run: |
         python -m pip install --upgrade pip
-        pip install tox
+        pip install gcovr
 
-    - name: Generate coverage and fix pkg name
-      env:
-        REAL_NAME: redis_ipc
+    - name: Configure and build (autotools)
       run: |
-        tox -e ctest,cover
+        autoreconf -fiv
+        ./configure --with-coverage
+        make cov || true
+
+    - name: Message bus
+      env:
+        RIPC_RUNTIME_DIR: "${{ env.TEMP_DIR }}"
+      run: |
+        ./scripts/run_redis.sh start
+
+    - name: Test (autotools)
+      env:
+        RIPC_SERVER_PATH: "${{ env.TEMP_DIR }}/socket"
+      run: |
+        make cov
+        gcovr -s -b src/.libs/ test/
+        gcovr --xml-pretty -o coverage.xml src/.libs/ test/
         ./scripts/fix_pkg_name.sh
+
+    - name: Cleanup
+      env:
+        RIPC_RUNTIME_DIR: "${{ env.TEMP_DIR }}"
+      run: |
+        ./scripts/run_redis.sh stop
 
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/env.yml
+++ b/.github/workflows/env.yml
@@ -1,0 +1,108 @@
+name: Runtime
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    branches: [ master, develop ]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set platform server (socket) dir
+      id: set_temp_dirs
+      run: |
+        MKTEMP=$(mktemp -d)
+        echo "Platform temp dir is: ${MKTEMP}"
+        echo "GH CI temp dir is: ${RUNNER_TEMP}"
+        if [ "${ImageOS}" != "ubuntu18" ]
+        then
+            TEMP_DIR="${MKTEMP}"
+        else
+            TEMP_DIR="${RUNNER_TEMP}"
+        fi
+        echo "Setting runtime dir: ${TEMP_DIR}"
+        echo "TEMP_DIR=${TEMP_DIR}" >> $GITHUB_ENV
+        bash -c set
+
+    # we split the deps for ubunti json-c versions:
+    #   bionic has json-c = 0.12 but focal
+    #   has a broken 0.13 so we use 0.15 instead
+    - name: Upstream
+      if: matrix.os == 'ubuntu-18.04'
+      run: |
+        sudo apt-get -qq update
+        sudo apt-get install -y cmake libjson-c-dev
+
+    - name: Common dependencies
+      run: >
+        sudo apt-get install -y
+        libhiredis-dev
+        redis-server
+        autoconf
+        automake
+        gcovr
+        lcov
+
+    - name: Backports
+      if: matrix.os == 'ubuntu-20.04'
+      run: |
+        sudo apt-get -qq update
+        sudo apt-get install -y software-properties-common
+        sudo add-apt-repository -y -s ppa:nerdboy/embedded
+        sudo apt-get install -y libjson-c-dev
+
+    - name: Configure and build (autotools)
+      if: matrix.os == 'ubuntu-20.04'
+      run: |
+        autoreconf -fiv
+        ./configure --with-coverage
+        make cov || true
+
+    - name: Configure and build (cmake)
+      if: matrix.os == 'ubuntu-18.04'
+      run: |
+        cmake -S . -B build -DWITH_COVERAGE=1 -DCMAKE_BUILD_TYPE=Debug
+        cmake --build build -j 2
+
+    - name: Message bus
+      env:
+        RIPC_RUNTIME_DIR: "${{ env.TEMP_DIR }}"
+      run: |
+        ./scripts/run_redis.sh start
+
+    - name: Test (autotools)
+      if: matrix.os == 'ubuntu-20.04'
+      env:
+        RIPC_SERVER_PATH: "${{ env.TEMP_DIR }}/socket"
+      run: |
+        make cov
+        gcovr -s -b src/.libs/ test/
+
+    - name: Test (ctest)
+      if: matrix.os == 'ubuntu-18.04'
+      env:
+        RIPC_SERVER_PATH: "${{ env.TEMP_DIR }}/socket"
+      run: |
+        ctest -V --test-dir build/
+        gcovr -s -b build/
+
+    - name: Cleanup
+      env:
+        RIPC_RUNTIME_DIR: "${{ env.TEMP_DIR }}"
+      run: |
+        ./scripts/run_redis.sh stop

--- a/.github/workflows/env.yml
+++ b/.github/workflows/env.yml
@@ -23,6 +23,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+
     - name: Set platform server (socket) dir
       id: set_temp_dirs
       run: |
@@ -38,6 +42,11 @@ jobs:
         echo "Setting runtime dir: ${TEMP_DIR}"
         echo "TEMP_DIR=${TEMP_DIR}" >> $GITHUB_ENV
         bash -c set
+
+    - name: Add python requirements
+      run: |
+        python -m pip install --upgrade pip
+        pip install gcovr
 
     # we split the deps for ubunti json-c versions:
     #   bionic has json-c = 0.12 but focal
@@ -55,7 +64,6 @@ jobs:
         redis-server
         autoconf
         automake
-        gcovr
         lcov
 
     - name: Backports
@@ -99,7 +107,7 @@ jobs:
         RIPC_SERVER_PATH: "${{ env.TEMP_DIR }}/socket"
       run: |
         ctest -V --test-dir build/
-        gcovr -s -b build/
+        gcovr --config gcovr.cfg -r . -s -b build/
 
     - name: Cleanup
       env:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -39,14 +39,6 @@ jobs:
     # we split the deps for ubunti json-c versions:
     #   bionic has json-c = 0.12 but focal
     #   has a broken 0.13 so we use 0.15 instead
-    - name: Backports
-      if: matrix.os == 'ubuntu-20.04'
-      run: |
-        sudo apt-get -qq update
-        sudo apt-get install -y software-properties-common
-        sudo add-apt-repository -y -s ppa:nerdboy/embedded
-        sudo apt-get install -y libjson-c-dev lcov autoconf automake
-
     - name: Upstream
       if: matrix.os == 'ubuntu-18.04'
       run: |
@@ -55,8 +47,15 @@ jobs:
 
     - name: Common dependencies
       run: |
-        sudo apt-get install -y libhiredis-dev
-        sudo apt-get install -y redis-server gcovr
+        sudo apt-get -qq update
+        sudo apt-get install -y libhiredis-dev redis-server
+
+    - name: Backports
+      if: matrix.os == 'ubuntu-20.04'
+      run: |
+        sudo apt-get install -y software-properties-common lcov autoconf automake
+        sudo add-apt-repository -y -s ppa:nerdboy/embedded
+        sudo apt-get install -y libjson-c-dev
 
     - name: Add python requirements
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,10 +50,16 @@ option(BUILD_STATIC_LIBS "Build static libraries" OFF)
 option(RIPC_BUILD_TESTING "build and run tests" ON)
 option(RIPC_DISABLE_SOCK_TESTS "disable tests requiring redis socket" OFF)
 
+option(RIPC_RUNTIME_DIR "Default path to directory containing redis server socket")
+
 set(WITH_COVERAGE "" CACHE PATH "build with test coverage enabled")
 
 set(INSTALL_PKGCONFIG_DIR "${CMAKE_INSTALL_PREFIX}/share/pkgconfig" CACHE PATH "Install directory for pkgconfig (.pc) files")
 set(EXTRA_TARGET_LINK_LIBRARIES)
+
+if(DEFINED RIPC_RUNTIME_DIR)
+    add_compile_options(-DRIPC_RUNTIME_DIR=\"${RIPC_RUNTIME_DIR}\")
+endif()
 
 if(WITH_COVERAGE)
     add_compile_options(--coverage)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,15 +50,22 @@ option(BUILD_STATIC_LIBS "Build static libraries" OFF)
 option(RIPC_BUILD_TESTING "build and run tests" ON)
 option(RIPC_DISABLE_SOCK_TESTS "disable tests requiring redis socket" OFF)
 
-option(RIPC_RUNTIME_DIR "Default path to directory containing redis server socket")
+set(RIPC_RUNTIME_DIR "" CACHE PATH "path to directory containing redis server socket")
 
 set(WITH_COVERAGE "" CACHE PATH "build with test coverage enabled")
 
 set(INSTALL_PKGCONFIG_DIR "${CMAKE_INSTALL_PREFIX}/share/pkgconfig" CACHE PATH "Install directory for pkgconfig (.pc) files")
 set(EXTRA_TARGET_LINK_LIBRARIES)
 
-if(DEFINED RIPC_RUNTIME_DIR)
-    add_compile_options(-DRIPC_RUNTIME_DIR=\"${RIPC_RUNTIME_DIR}\")
+# accept cmake option -or- environment variable
+if(DEFINED ENV{RIPC_RUNTIME_DIR})
+  message(STATUS "Found socket path in ENV: $ENV{RIPC_RUNTIME_DIR}")
+  set(RUNTIME_DIR "$ENV{RIPC_RUNTIME_DIR}")
+  add_compile_definitions(RIPC_RUNTIME_DIR="${RUNTIME_DIR}")
+elseif(RIPC_RUNTIME_DIR)
+  message(STATUS "Got cmake option RIPC_RUNTIME_DIR: ${RIPC_RUNTIME_DIR}")
+  set(RUNTIME_DIR "${RIPC_RUNTIME_DIR}")
+  add_compile_definitions(RIPC_RUNTIME_DIR="${RUNTIME_DIR}")
 endif()
 
 if(WITH_COVERAGE)

--- a/README.rst
+++ b/README.rst
@@ -361,8 +361,10 @@ Running redis-ipc
 =================
 
 After building redis-ipc for the desired platform, try running it against a redis server.
-The redis server needs to be configured to use a unix socket, the path of which is
-currently hard-coded to /tmp/redis-ipc/socket in this library
+The redis server needs to be configured to use a unix socket, the path of which
+defaults to $RPC_RUNTIME_DIR/socket, where RPC_RUNTIME_DIR defaults to /tmp/redis-ipc
+but may be overridden at compile time. The socket path may also be overridden at
+runtime with the environment variable `RIPC_SERVER_PATH`.
 
 redis.conf excerpt::
 

--- a/configure.ac
+++ b/configure.ac
@@ -124,6 +124,9 @@ fi
 AC_DEFINE_UNQUOTED(ENABLE_DEBUG, `enable_value $enable_debug`, [Enable debugging])
 AC_DEFINE_UNQUOTED(ENABLE_GPROF, `enable_value $enable_gprof`, [Enable gcc profiling])
 
+AC_ARG_VAR(RIPC_RUNTIME_DIR, [Supply default path to directory containing redis server socket])
+AM_CONDITIONAL([RIPC_RUNTIME_DIR], [test x$RIPC_RUNTIME_DIR != x])
+
 PKG_INSTALLDIR
 
 AC_CONFIG_FILES([Makefile \

--- a/scripts/run_redis.sh
+++ b/scripts/run_redis.sh
@@ -13,21 +13,21 @@ trap 'failures=$((failures+1))' ERR
 CMD_ARG=${1:-status}
 PORT=${PORT:-0}
 VERBOSE="false"  # set to "true" for extra output
-export RIPC_RUNTIME_DIR=${RIPC_RUNTIME_DIR:-/tmp}
+export RIPC_RUNTIME_DIR=${RIPC_RUNTIME_DIR:-/tmp/redis-ipc}
 
 echo "Using socket runtime dir: ${RIPC_RUNTIME_DIR}"
 
 if [[ "${CMD_ARG}" = "status" ]]; then
     [[ "${VERBOSE}" = "true" ]]  && echo "pinging redis-server on local socket..."
-    redis-cli -s ${RIPC_RUNTIME_DIR}/redis-ipc/socket ping
+    redis-cli -s ${RIPC_RUNTIME_DIR}/socket ping
 fi
 
 if [[ "${CMD_ARG}" = "start" ]]; then
     [[ "${VERBOSE}" = "true" ]]  && echo "starting redis-server on local socket..."
-    mkdir -p ${RIPC_RUNTIME_DIR}/redis-ipc/
-    redis-server --port ${PORT} --pidfile ${RIPC_RUNTIME_DIR}/redis.pid --unixsocket ${RIPC_RUNTIME_DIR}/redis-ipc/socket --unixsocketperm 600 &
+    mkdir -p ${RIPC_RUNTIME_DIR}
+    redis-server --port ${PORT} --pidfile ${RIPC_RUNTIME_DIR}/redis.pid --unixsocket ${RIPC_RUNTIME_DIR}/socket --unixsocketperm 600 &
     sleep 1
-    redis-cli -s ${RIPC_RUNTIME_DIR}/redis-ipc/socket config set save ""
+    redis-cli -s ${RIPC_RUNTIME_DIR}/socket config set save ""
 fi
 
 if [[ "${CMD_ARG}" = "stop" ]]; then

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,8 @@
-AM_CPPFLAGS             = -I$(top_srcdir)/src
+if RIPC_RUNTIME_DIR
+PATH_FLAG = -DRIPC_RUNTIME_DIR=\"$(RIPC_RUNTIME_DIR)\"
+endif
+
+AM_CPPFLAGS             = -I$(top_srcdir)/src $(PATH_FLAG)
 
 lib_LTLIBRARIES = libredis_ipc.la
 

--- a/src/redis_ipc.c
+++ b/src/redis_ipc.c
@@ -27,6 +27,7 @@ struct redis_ipc_per_thread
     char *thread;             // thread name used in redis
     char *result_queue_path;  // based on component and thread
     redisContext *redis_state;  // state for connection to redis server
+    const char *redis_socket_path;  // path for connection to redis server
     unsigned int command_ctr;   // counter for number of commands sent by thread
 };
 
@@ -166,8 +167,13 @@ int redis_ipc_init(const char *this_component, const char *this_thread)
     // tid is OS thread ID number
     new_info->tid = gettid();
 
+    // path to redis server socket can be overridden from environment
+    new_info->redis_socket_path = getenv("RIPC_SERVER_PATH");
+    if (new_info->redis_socket_path == NULL)
+        new_info->redis_socket_path = RIPC_SERVER_PATH;
+
     // each thread gets its own redis connection
-    new_info->redis_state = redisConnectUnix(RIPC_SERVER_PATH);
+    new_info->redis_state = redisConnectUnix(new_info->redis_socket_path);
     if (new_info->redis_state == NULL || new_info->redis_state->err)
         goto redis_ipc_init_failed;
 

--- a/src/redis_ipc.h
+++ b/src/redis_ipc.h
@@ -42,7 +42,13 @@ enum { RIPC_DBG_ERROR,
 #define RIPC_MAX_IPC_PATH_LEN 128
 
 // redis server address
-#define RIPC_SERVER_PATH "/tmp/redis-ipc/socket"
+#ifdef RIPC_RUNTIME_DIR
+#pragma message "RIPC_RUNTIME_DIR was set"
+#else
+#pragma message "RIPC_RUNTIME_DIR was *not* set"
+#define RIPC_RUNTIME_DIR "/tmp/redis-ipc"
+#endif
+#define RIPC_SERVER_PATH RIPC_RUNTIME_DIR "/socket"
 
 //*************
 // functions

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,4 +1,8 @@
-AM_CPPFLAGS    = -I$(top_srcdir)/inc -I$(top_srcdir)/src -I$(includedir)
+if RIPC_RUNTIME_DIR
+PATH_FLAG = -DRIPC_RUNTIME_DIR=\"$(RIPC_RUNTIME_DIR)\"
+endif
+
+AM_CPPFLAGS    = -I$(top_srcdir)/inc -I$(top_srcdir)/src -I$(includedir) $(PATH_FLAG)
 
 LIBREDISIPC = $(top_srcdir)/src/.libs/libredis_ipc.la
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,17 +8,20 @@ envdir = {toxinidir}/.env
 skip_install = true
 
 passenv =
+    RIPC_RUNTIME_DIR
     pythonLocation
     CI GITHUB*
     PIP_DOWNLOAD_CACHE
-    RIPC_RUNTIME_DIR
+
+setenv =
+    {auto,bionic}: RIPC_SERVER_PATH = {env:RIPC_SERVER_PATH:{envtmpdir}/socket}
 
 whitelist_externals =
     {tests,clang,ctest,bionic,lint,grind,clean,auto,autoclean}: bash
     {tests,clang,bionic,grind,cover}: mkdir
 
 changedir =
-    {tests,clang,bionic,grind}: build
+    {tests,clang,grind}: build
 
 deps =
     {auto,tests,clang,ctest,bionic,grind,lint,cover}: pip>=19.0.1
@@ -32,44 +35,49 @@ deps =
 commands_pre =
     bionic: mkdir -p {toxinidir}/coverage
     {tests,clang,bionic,grind}: mkdir -p {toxinidir}/build
-    {auto,tests,clang,ctest,bionic,grind}: bash -c "{toxinidir}/scripts/run_redis.sh start > /dev/null"
-    {auto,tests,clang,ctest,bionic,grind}: bash -c "{toxinidir}/scripts/run_redis.sh status"
+    {tests,clang,ctest,grind}: bash -c '{toxinidir}/scripts/run_redis.sh start > /dev/null'
+    {tests,clang,ctest,grind}: bash -c '{toxinidir}/scripts/run_redis.sh status'
+    {auto,bionic}: bash -c 'RIPC_RUNTIME_DIR={envtmpdir} {toxinidir}/scripts/run_redis.sh start > /dev/null'
+    {auto,bionic}: bash -c 'RIPC_RUNTIME_DIR={envtmpdir} {toxinidir}/scripts/run_redis.sh status'
 
 commands =
     # sadly this-cli cannot pass args to configure
     #auto: this check
-    auto: bash -c './autogen.sh'
+    auto: bash -c 'autoreconf -fiv'
     auto: bash -c './configure {posargs:"--with-coverage"}'
     auto: bash -c 'make cov'
-    bionic: bash -c "cmake -DWITH_COVERAGE=1 -DCMAKE_BUILD_TYPE=Debug -DGOOGLETEST_SRC_DIR=/usr/src/googletest .."
-    clang: bash -c "cmake -DCMAKE_TOOLCHAIN_FILE=../clang_toolchain.cmake .."
-    tests: bash -c "cmake -DWITH_COVERAGE=1 -DCMAKE_BUILD_TYPE=Debug .."
-    grind: bash -c "cmake -DCMAKE_BUILD_TYPE=Debug .."
-    {tests,clang,bionic,grind}: bash -c "cmake --build . -j $(nproc)"
-    {tests,clang,bionic,grind}: bash -c "ctest -V --test-dir ./"
-    lint: bash -c "cpplint --output=gsed {toxinidir}/src/* {toxinidir}/inc/*"
-    {tests,bionic}: gcovr -s -b -r {toxinidir} .
+    bionic: bash -c 'cmake -G {posargs:"Unix Makefiles"} -S . -B build -DWITH_COVERAGE=1 -DCMAKE_BUILD_TYPE=Debug'
+    bionic: bash -c 'cmake --build build -j $(nproc)'
+    bionic: bash -c 'ctest -V --test-dir build/'
+    clang: bash -c 'cmake -DCMAKE_TOOLCHAIN_FILE=../clang_toolchain.cmake ..'
+    tests: bash -c 'cmake -DWITH_COVERAGE=1 -DCMAKE_BUILD_TYPE=Debug ..'
+    grind: bash -c 'cmake -DCMAKE_BUILD_TYPE=Debug ..'
+    {tests,clang,grind}: bash -c 'cmake --build . -j $(nproc)'
+    {tests,clang,grind}: bash -c 'ctest -V --test-dir ./'
+    lint: bash -c 'cpplint --output=gsed {toxinidir}/src/* {toxinidir}/inc/*'
+    tests: gcovr -s -b -r {toxinidir} .
     ctest: bash -c 'ctest --build-generator {posargs:"Unix Makefiles"} --build-and-test . build --build-options -DWITH_COVERAGE=ON -DCMAKE_BUILD_TYPE=Debug --test-command ctest --rerun-failed --output-on-failure -V'
     auto: gcovr -s -b src/.libs/ test/
     auto: gcovr --xml-pretty -o coverage.xml src/.libs/ test/
-    ctest: gcovr -s -b build/
+    {bionic,ctest}: gcovr -s -b build/
+    bionic: gcovr --html --html-details -o {toxinidir}/coverage/coverage.html build/
     cover: gcovr --xml-pretty -o coverage.xml build/
-    bionic: gcovr --html --html-details -o {toxinidir}/coverage/coverage.html .
     # runtime assertion error without || true =>  (SIGSEGV)) (exited with code -11)
-    grind: bash -c "valgrind --tool=memcheck --xml=yes --xml-file=json_check.xml --leak-check=full --show-leak-kinds=definite,possible --error-exitcode=127 ./json_test || true"
+    grind: bash -c 'valgrind --tool=memcheck --xml=yes --xml-file=json_check.xml --leak-check=full --show-leak-kinds=definite,possible --error-exitcode=127 ./json_test || true'
     # valgrind error exit without || true =>  (exited with code 127)
-    grind: bash -c "valgrind --tool=memcheck --xml=yes --xml-file=multithread_check.xml --leak-check=full --show-leak-kinds=definite,possible --error-exitcode=127 ./multithread_test || true"
-    grind: bash -c "valgrind --tool=memcheck --xml=yes --xml-file=command_check.xml --leak-check=full --show-leak-kinds=definite,possible --error-exitcode=127 ./command_result_test"
-    grind: bash -c "[[ -f json_check.xml ]] && valgrind-ci json_check.xml --number-of-errors"
-    grind: bash -c "[[ -f json_check.xml ]] && valgrind-ci json_check.xml --summary"
+    grind: bash -c 'valgrind --tool=memcheck --xml=yes --xml-file=multithread_check.xml --leak-check=full --show-leak-kinds=definite,possible --error-exitcode=127 ./multithread_test || true'
+    grind: bash -c 'valgrind --tool=memcheck --xml=yes --xml-file=command_check.xml --leak-check=full --show-leak-kinds=definite,possible --error-exitcode=127 ./command_result_test'
+    grind: bash -c '[[ -f json_check.xml ]] && valgrind-ci json_check.xml --number-of-errors'
+    grind: bash -c '[[ -f json_check.xml ]] && valgrind-ci json_check.xml --summary'
     grind: valgrind-ci multithread_check.xml --number-of-errors
     grind: valgrind-ci multithread_check.xml --summary
     # xml exception (no errors in report) =>  junk after document element
-    #grind: bash -c "[[ -f command_check.xml ]] && valgrind-ci command_check.xml --number-of-errors || true"
-    #grind: bash -c "[[ -f command_check.xml ]] && valgrind-ci command_check.xml --summary || true"
-    clean: bash -c 'rm -rf build/ coverage.xml'
+    #grind: bash -c '[[ -f command_check.xml ]] && valgrind-ci command_check.xml --number-of-errors || true'
+    #grind: bash -c '[[ -f command_check.xml ]] && valgrind-ci command_check.xml --summary || true'
+    clean: bash -c 'rm -rf build/ coverage/ coverage.xml'
     autoclean: bash -c 'make distclean-recursive'
     autoclean: bash -c 'rm -rf Makefile Makefile.in aclocal.m4 ar-lib autom4te.cache/ compile config.* coverage* configure configure~ depcomp install-sh libltdl/ ltmain.sh m4/ missing src/Makefile.in test-driver test/gmon.out test/Makefile.in'
 
 commands_post =
-    {auto,tests,clang,ctest,bionic,grind}: bash -c "{toxinidir}/scripts/run_redis.sh stop > /dev/null"
+    {auto,bionic}: bash -c 'RIPC_RUNTIME_DIR={envtmpdir} {toxinidir}/scripts/run_redis.sh stop'
+    {tests,clang,ctest,grind}: bash -c '{toxinidir}/scripts/run_redis.sh stop > /dev/null'

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ passenv =
     pythonLocation
     CI GITHUB*
     PIP_DOWNLOAD_CACHE
+    RIPC_RUNTIME_DIR
 
 whitelist_externals =
     {tests,clang,ctest,bionic,lint,grind,clean,auto,autoclean}: bash
@@ -48,7 +49,7 @@ commands =
     {tests,clang,bionic,grind}: bash -c "ctest -V --test-dir ./"
     lint: bash -c "cpplint --output=gsed {toxinidir}/src/* {toxinidir}/inc/*"
     {tests,bionic}: gcovr -s -b -r {toxinidir} .
-    ctest: bash -c 'ctest --build-generator {posargs:"Unix Makefiles"} --build-and-test . build --build-options -DWITH_COVERAGE=ON -DCMAKE_BUILD_TYPE=Debug --test-command ctest -V'
+    ctest: bash -c 'ctest --build-generator {posargs:"Unix Makefiles"} --build-and-test . build --build-options -DWITH_COVERAGE=ON -DCMAKE_BUILD_TYPE=Debug --test-command ctest --rerun-failed --output-on-failure -V'
     auto: gcovr -s -b src/.libs/ test/
     auto: gcovr --xml-pretty -o coverage.xml src/.libs/ test/
     ctest: gcovr -s -b build/


### PR DESCRIPTION
* compile-time configuration with RIPC_RUNTIME_DIR
  * with cmake
    cmake -DRIPC_RUNTIME_DIR=/var/tmp/redis-ipc
  * with automake
    export RIPC_RUNTIME_DIR=/var/tmp/redis-ipc ./configure

In each case, default path will be $RIPC_RUNTIME_DIR/socket
Note that matches the usage of RIPC_RUNTIME_DIR in scripts/run_redis.sh
If you set RIPC_RUNTIME_DIR when building, use the same value
when using run_redis.sh to setup for tests.

Path can be overrident at runtime by setting RIPC_SERVER_PATH
NOTE this is full path, not just the parent dir like RIPC_RUNTIME_DIR:
  export RIPC_SERVER_PATH=/var/tmp/redis-ipc/socket