### PR TITLE
add full cmake coverage, fix small nit in coverage xml report names

### DIFF
--- a/.github/workflows/env.yml
+++ b/.github/workflows/env.yml
@@ -51,26 +51,23 @@ jobs:
     # we split the deps for ubunti json-c versions:
     #   bionic has json-c = 0.12 but focal
     #   has a broken 0.13 so we use 0.15 instead
-    - name: Upstream
+    #   otoh, bionic has old lcov without --include support
+    - name: Common dependencies
+      run: |
+        sudo apt-get -qq update
+        sudo apt-get install -y libhiredis-dev redis-server
+
+    - name: Backports (bionic)
       if: matrix.os == 'ubuntu-18.04'
       run: |
-        sudo apt-get -qq update
-        sudo apt-get install -y cmake libjson-c-dev
+        sudo apt-get install -y software-properties-common libjson-c-dev
+        sudo add-apt-repository -y -s ppa:nerdboy/embedded
+        sudo apt-get install -y lcov
 
-    - name: Common dependencies
-      run: >
-        sudo apt-get install -y
-        libhiredis-dev
-        redis-server
-        autoconf
-        automake
-        lcov
-
-    - name: Backports
+    - name: Backports (focal)
       if: matrix.os == 'ubuntu-20.04'
       run: |
-        sudo apt-get -qq update
-        sudo apt-get install -y software-properties-common
+        sudo apt-get install -y software-properties-common autoconf automake lcov
         sudo add-apt-repository -y -s ppa:nerdboy/embedded
         sudo apt-get install -y libjson-c-dev
 
@@ -86,6 +83,7 @@ jobs:
       run: |
         cmake -S . -B build -DWITH_COVERAGE=1 -DCMAKE_BUILD_TYPE=Debug
         cmake --build build -j 2
+        make cov || true
 
     - name: Message bus
       env:
@@ -106,7 +104,7 @@ jobs:
       env:
         RIPC_SERVER_PATH: "${{ env.TEMP_DIR }}/socket"
       run: |
-        ctest -V --test-dir build/
+        ctest --build-target cov --test-dir build/
         gcovr --config gcovr.cfg -r . -s -b build/
 
     - name: Cleanup

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -39,21 +39,23 @@ jobs:
     # we split the deps for ubunti json-c versions:
     #   bionic has json-c = 0.12 but focal
     #   has a broken 0.13 so we use 0.15 instead
-    - name: Upstream
-      if: matrix.os == 'ubuntu-18.04'
-      run: |
-        sudo apt-get -qq update
-        sudo apt-get install -y libjson-c-dev
-
+    #   otoh, bionic has old lcov without --include support
     - name: Common dependencies
       run: |
         sudo apt-get -qq update
-        sudo apt-get install -y libhiredis-dev redis-server lcov
+        sudo apt-get install -y libhiredis-dev redis-server
 
-    - name: Backports
+    - name: Backports (bionic)
+      if: matrix.os == 'ubuntu-18.04'
+      run: |
+        sudo apt-get install -y software-properties-common libjson-c-dev
+        sudo add-apt-repository -y -s ppa:nerdboy/embedded
+        sudo apt-get install -y lcov
+
+    - name: Backports (focal)
       if: matrix.os == 'ubuntu-20.04'
       run: |
-        sudo apt-get install -y software-properties-common autoconf automake
+        sudo apt-get install -y software-properties-common autoconf automake lcov
         sudo add-apt-repository -y -s ppa:nerdboy/embedded
         sudo apt-get install -y libjson-c-dev
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -48,12 +48,12 @@ jobs:
     - name: Common dependencies
       run: |
         sudo apt-get -qq update
-        sudo apt-get install -y libhiredis-dev redis-server
+        sudo apt-get install -y libhiredis-dev redis-server lcov
 
     - name: Backports
       if: matrix.os == 'ubuntu-20.04'
       run: |
-        sudo apt-get install -y software-properties-common lcov autoconf automake
+        sudo apt-get install -y software-properties-common autoconf automake
         sudo add-apt-repository -y -s ppa:nerdboy/embedded
         sudo apt-get install -y libjson-c-dev
 

--- a/.lcovrc
+++ b/.lcovrc
@@ -2,7 +2,7 @@
 #
 #genhtml_css_file = gcov.css
 
-genhtml_branch_coverage = 0
+genhtml_branch_coverage = 1
 genhtml_function_coverage = 1
 genhtml_charset=UTF-8
 #genhtml_demangle_cpp=1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 
 set(RIPC_SONAME ${LIBRARY_VERSION})
 
-project(redis_ipc VERSION ${LIBRARY_VERSION} LANGUAGES C CXX)
+project(redis-ipc VERSION ${LIBRARY_VERSION} LANGUAGES C CXX)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_VERBOSE_MAKEFILE ON)
@@ -47,7 +47,7 @@ endif()
 option(BUILD_SHARED_LIBS "build shared libraries" ON)
 option(BUILD_STATIC_LIBS "Build static libraries" OFF)
 
-option(RIPC_BUILD_TESTING "build and run tests" ON)
+option(RIPC_BUILD_TESTING "build and run tests" OFF)
 option(RIPC_DISABLE_SOCK_TESTS "disable tests requiring redis socket" OFF)
 
 set(RIPC_RUNTIME_DIR "" CACHE PATH "path to directory containing redis server socket")
@@ -68,9 +68,12 @@ elseif(RIPC_RUNTIME_DIR)
   add_compile_definitions(RIPC_RUNTIME_DIR="${RUNTIME_DIR}")
 endif()
 
+# Adds custom target for lcov report generation (does not build, only runs test cmd).
+# Note: "make cov" target must be run both with/without RIPC_RUNTIME_DIR override
+# in order to generate full coverage data.
 if(WITH_COVERAGE)
-    add_compile_options(--coverage)
-    add_link_options(--coverage)
+  set(RIPC_BUILD_TESTING ON)
+  include(TestCoverage)
 endif()
 
 #include(FindJSONC)
@@ -147,6 +150,7 @@ set_target_properties(redis_ipc
     )
 
 if(RIPC_BUILD_TESTING)
+  enable_testing()
   if (NOT RIPC_DISABLE_SOCK_TESTS)
     set(TEST_TARGETS
         command_result_test

--- a/cmake/TestCoverage.cmake
+++ b/cmake/TestCoverage.cmake
@@ -1,0 +1,41 @@
+set(CMAKE_C_FLAGS "-g -O0 --coverage")
+set(CMAKE_CXX_FLAGS "-g -O0 --coverage")
+set(CMAKE_EXE_LINKER_FLAGS "--coverage")
+set(CMAKE_SHARED_LINKER_FLAGS "--coverage")
+
+set(COVERAGE_OUTPUT_DIR "${CMAKE_SOURCE_DIR}/coverage")
+set(TRACEFILE "${CMAKE_SOURCE_DIR}/coverage.info")
+set(REPORT_DIR "${COVERAGE_OUTPUT_DIR}")
+
+add_custom_command(
+    OUTPUT "${TRACEFILE}" always
+
+    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+
+    COMMAND ${CMAKE_COMMAND} -E remove "${TRACEFILE}"
+
+    COMMAND ${CMAKE_COMMAND} -E remove_directory "${COVERAGE_OUTPUT_DIR}"
+
+    COMMAND ${CMAKE_CTEST_COMMAND}  # execute default test suite
+
+    COMMAND lcov
+                --config-file "${CMAKE_SOURCE_DIR}/.lcovrc"
+                --capture
+                --directory "${CMAKE_BINARY_DIR}"
+                --include "${CMAKE_SOURCE_DIR}/src/redis_ipc.c"
+                --include "${CMAKE_SOURCE_DIR}/src/redis_ipc.h"
+                --include "${CMAKE_SOURCE_DIR}/inc/json.hh"
+                --output-file "${TRACEFILE}"
+
+    COMMAND genhtml ${TRACEFILE}
+                --prefix "."
+                --title "${CMAKE_PROJECT_NAME}"
+                --legend --show-details
+                --output-directory ${REPORT_DIR}
+
+    VERBATIM  # for correct handling of wildcards in command line parameters
+)
+
+add_custom_target(cov
+    DEPENDS ${TRACEFILE} always
+)

--- a/scripts/fix_pkg_name.sh
+++ b/scripts/fix_pkg_name.sh
@@ -20,7 +20,10 @@ VERBOSE="false"  # set to "true" for extra output
 
 NAME_CHECK=$(grep -o 'name=""' "${COV_FILE}" || true)
 
-[[ -z "$NAME_CHECK" ]] && echo "Nothing to fix ..." && exit 0
+# extra fix for autotools ??
+sed -i -e "s|src..libs|src|" $COV_FILE
+
+[[ -z "$NAME_CHECK" ]] && echo "No name to fix ..." && exit 0
 [[ -n $REAL_NAME ]] || REAL_NAME=$(grep ^name setup.cfg | cut -d" " -f3)
 [[ -n $REAL_NAME ]] && sed -i -e "s|name=\"\"|name=\"${REAL_NAME}\"|" $COV_FILE
 [[ -n $REAL_NAME ]] && echo "Replaced \"\" with ${REAL_NAME} in ${COV_FILE} ..."

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ whitelist_externals =
     {tests,clang,bionic,grind,cover}: mkdir
 
 changedir =
-    {tests,clang,grind}: build
+    {tests,bionic,clang,grind}: build
 
 deps =
     {auto,tests,clang,ctest,bionic,grind,lint,cover}: pip>=19.0.1
@@ -40,29 +40,28 @@ commands_pre =
 commands =
     # sadly this-cli cannot pass args to configure
     #auto: this check
+    bionic: bash -c 'cmake -G {posargs:"Unix Makefiles"} -DWITH_COVERAGE=1 -DCMAKE_BUILD_TYPE=Debug ..'
+    bionic: bash -c 'cmake --build .'
     auto: bash -c 'autoreconf -fiv'
     auto: bash -c './configure {posargs:"--with-coverage"}'
-    auto: bash -c 'make cov || true'
-    bionic: bash -c 'cmake -G {posargs:"Unix Makefiles"} -S . -B build -DWITH_COVERAGE=1 -DCMAKE_BUILD_TYPE=Debug'
-    bionic: bash -c 'cmake --build build -j $(nproc)'
+    {auto,bionic}: bash -c 'make cov || true'
     {auto,bionic}: bash -c 'RIPC_RUNTIME_DIR=$ENV_RIPC_RUNTIME_DIR {toxinidir}/scripts/run_redis.sh start > /dev/null'
     {auto,bionic}: bash -c 'RIPC_RUNTIME_DIR=$ENV_RIPC_RUNTIME_DIR {toxinidir}/scripts/run_redis.sh status'
-    auto: bash -c 'RIPC_SERVER_PATH=$ENV_RIPC_RUNTIME_DIR/socket make cov'
-    bionic: bash -c 'RIPC_SERVER_PATH=$ENV_RIPC_RUNTIME_DIR/socket ctest -V --test-dir build/'
-    clang: bash -c 'cmake -DCMAKE_TOOLCHAIN_FILE=../clang_toolchain.cmake ..'
+    {auto,bionic}: bash -c 'RIPC_SERVER_PATH=$ENV_RIPC_RUNTIME_DIR/socket make cov'
+    clang: bash -c 'cmake -DRIPC_BUILD_TESTING=ON -DCMAKE_TOOLCHAIN_FILE=../clang_toolchain.cmake ..'
     tests: bash -c 'cmake -DWITH_COVERAGE=1 -DCMAKE_BUILD_TYPE=Debug ..'
-    grind: bash -c 'cmake -DCMAKE_BUILD_TYPE=Debug ..'
+    grind: bash -c 'cmake -DRIPC_BUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug ..'
     {tests,clang,grind}: bash -c 'cmake --build . -j $(nproc)'
     {tests,clang,grind}: bash -c 'ctest -V --test-dir ./'
     lint: bash -c 'cpplint --output=gsed {toxinidir}/src/* {toxinidir}/inc/*'
-    tests: gcovr -s -b -r {toxinidir} .
-    ctest: bash -c 'ctest --build-generator {posargs:"Unix Makefiles"} --build-and-test . build --build-options -DWITH_COVERAGE=ON -DCMAKE_BUILD_TYPE=Debug --test-command ctest --rerun-failed --output-on-failure -V'
     auto: gcovr -s -b src/.libs/ test/
     auto: gcovr --xml-pretty -o coverage.xml src/.libs/ test/
-    {bionic,ctest}: gcovr -s -b build/
-    bionic: gcovr --html --html-details -o {toxinidir}/coverage/coverage.html build/
-    cover: gcovr --xml-pretty -o coverage.xml build/
+    {bionic,tests}: gcovr -s -b -r {toxinidir} .
+    bionic: gcovr -r {toxinidir} --xml-pretty -o coverage.xml .
     {auto,bionic}: bash -c 'RIPC_RUNTIME_DIR=$ENV_RIPC_RUNTIME_DIR {toxinidir}/scripts/run_redis.sh stop'
+    ctest: bash -c 'ctest --build-generator {posargs:"Unix Makefiles"} --build-and-test . build --build-options -DWITH_COVERAGE=ON -DCMAKE_BUILD_TYPE=Debug --test-command ctest --rerun-failed --output-on-failure -V'
+    ctest: gcovr -s -b build/
+    cover: gcovr --xml-pretty -o coverage.xml build/
     # runtime assertion error without || true =>  (SIGSEGV)) (exited with code -11)
     grind: bash -c 'valgrind --tool=memcheck --xml=yes --xml-file=json_check.xml --leak-check=full --show-leak-kinds=definite,possible --error-exitcode=127 ./json_test || true'
     # valgrind error exit without || true =>  (exited with code 127)

--- a/tox.ini
+++ b/tox.ini
@@ -8,13 +8,12 @@ envdir = {toxinidir}/.env
 skip_install = true
 
 passenv =
-    RIPC_RUNTIME_DIR
     pythonLocation
     CI GITHUB*
     PIP_DOWNLOAD_CACHE
 
 setenv =
-    {auto,bionic}: RIPC_SERVER_PATH = {env:RIPC_SERVER_PATH:{envtmpdir}/socket}
+    {auto,bionic}: ENV_RIPC_RUNTIME_DIR = {env:ENV_RIPC_RUNTIME_DIR:{envtmpdir}}
 
 whitelist_externals =
     {tests,clang,ctest,bionic,lint,grind,clean,auto,autoclean}: bash
@@ -37,18 +36,19 @@ commands_pre =
     {tests,clang,bionic,grind}: mkdir -p {toxinidir}/build
     {tests,clang,ctest,grind}: bash -c '{toxinidir}/scripts/run_redis.sh start > /dev/null'
     {tests,clang,ctest,grind}: bash -c '{toxinidir}/scripts/run_redis.sh status'
-    {auto,bionic}: bash -c 'RIPC_RUNTIME_DIR={envtmpdir} {toxinidir}/scripts/run_redis.sh start > /dev/null'
-    {auto,bionic}: bash -c 'RIPC_RUNTIME_DIR={envtmpdir} {toxinidir}/scripts/run_redis.sh status'
 
 commands =
     # sadly this-cli cannot pass args to configure
     #auto: this check
     auto: bash -c 'autoreconf -fiv'
     auto: bash -c './configure {posargs:"--with-coverage"}'
-    auto: bash -c 'make cov'
+    auto: bash -c 'make cov || true'
     bionic: bash -c 'cmake -G {posargs:"Unix Makefiles"} -S . -B build -DWITH_COVERAGE=1 -DCMAKE_BUILD_TYPE=Debug'
     bionic: bash -c 'cmake --build build -j $(nproc)'
-    bionic: bash -c 'ctest -V --test-dir build/'
+    {auto,bionic}: bash -c 'RIPC_RUNTIME_DIR=$ENV_RIPC_RUNTIME_DIR {toxinidir}/scripts/run_redis.sh start > /dev/null'
+    {auto,bionic}: bash -c 'RIPC_RUNTIME_DIR=$ENV_RIPC_RUNTIME_DIR {toxinidir}/scripts/run_redis.sh status'
+    auto: bash -c 'RIPC_SERVER_PATH=$ENV_RIPC_RUNTIME_DIR/socket make cov'
+    bionic: bash -c 'RIPC_SERVER_PATH=$ENV_RIPC_RUNTIME_DIR/socket ctest -V --test-dir build/'
     clang: bash -c 'cmake -DCMAKE_TOOLCHAIN_FILE=../clang_toolchain.cmake ..'
     tests: bash -c 'cmake -DWITH_COVERAGE=1 -DCMAKE_BUILD_TYPE=Debug ..'
     grind: bash -c 'cmake -DCMAKE_BUILD_TYPE=Debug ..'
@@ -62,6 +62,7 @@ commands =
     {bionic,ctest}: gcovr -s -b build/
     bionic: gcovr --html --html-details -o {toxinidir}/coverage/coverage.html build/
     cover: gcovr --xml-pretty -o coverage.xml build/
+    {auto,bionic}: bash -c 'RIPC_RUNTIME_DIR=$ENV_RIPC_RUNTIME_DIR {toxinidir}/scripts/run_redis.sh stop'
     # runtime assertion error without || true =>  (SIGSEGV)) (exited with code -11)
     grind: bash -c 'valgrind --tool=memcheck --xml=yes --xml-file=json_check.xml --leak-check=full --show-leak-kinds=definite,possible --error-exitcode=127 ./json_test || true'
     # valgrind error exit without || true =>  (exited with code 127)
@@ -79,5 +80,4 @@ commands =
     autoclean: bash -c 'rm -rf Makefile Makefile.in aclocal.m4 ar-lib autom4te.cache/ compile config.* coverage* configure configure~ depcomp install-sh libltdl/ ltmain.sh m4/ missing src/Makefile.in test-driver test/gmon.out test/Makefile.in'
 
 commands_post =
-    {auto,bionic}: bash -c 'RIPC_RUNTIME_DIR={envtmpdir} {toxinidir}/scripts/run_redis.sh stop'
     {tests,clang,ctest,grind}: bash -c '{toxinidir}/scripts/run_redis.sh stop > /dev/null'


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfills
all of the requirements below. If you cannot currently tick all the boxes,
but would still like to create a PR, then add the label "WIP" and assign
the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit
as the bug fix. Else, keep commits small and orthogonal, possibly placing
tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behavior I have added or modified has been documented in the README file.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See `.gitchangelog.rc` in the top-level repo directory for guidance on
commit message summary formatting and tags.  Please use the appropriate
action and/or audience markers in the first line of your commit messages.

See also, e.g., https://chris.beams.io/posts/git-commit/ for general
guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated
white-space changes, use git rebase or a sequence involving git reset
and git add -p to fix this.
--->
* fix cosmetic nit in PR report summary
* isolate internal env, override via ENV_RIPC_RUNTIME_DIR
* define package (internal) env var names using tox defaults
* move tox env commands to replicate workflow
* add cmake module to replicate makefile.am lcov/genhtml commands
* move lcov to common deps in smoke workflow
* note full coverage reqiures 2 passes, one with and one without the runtime socket path override (true for both autotools and cmake builds)
* enabling cmake coverage also enables building test binaries; both are currently OFF by default
  - WITH_COVERAGE enables RIPC_BUILD_TESTING
  - enable RIPC_BUILD_TESTING to build test binaries only
