### PR TITLE
Fix generated pkgconfig file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,5 +202,6 @@ install(EXPORT redis_ipcConfig
 
 
 set(RIPC_PC ${CMAKE_CURRENT_BINARY_DIR}/redis-ipc.pc)
+set(prefix ${CMAKE_INSTALL_PREFIX})
 configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/redis-ipc.pc.in ${RIPC_PC} @ONLY)
 install(FILES ${RIPC_PC} DESTINATION ${INSTALL_PKGCONFIG_DIR})


### PR DESCRIPTION
Now the @prefix@ in redis-ipc.pc.in should get substituted when building
with cmake (already worked for autotools builds)

<!---
Thank you for your contribution. Please make sure your pull request fulfills
all of the requirements below. If you cannot currently tick all the boxes,
but would still like to create a PR, then add the label "WIP" and assign
the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit
as the bug fix. Else, keep commits small and orthogonal, possibly placing
tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behavior I have added or modified has been documented in the README file.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See `.gitchangelog.rc` in the top-level repo directory for guidance on
commit message summary formatting and tags.  Please use the appropriate
action and/or audience markers in the first line of your commit messages.

See also, e.g., https://chris.beams.io/posts/git-commit/ for general
guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated
white-space changes, use git rebase or a sequence involving git reset
and git add -p to fix this.
--->
