### PR TITLE
Json class cleanups

### DIFF
--- a/inc/json.hh
+++ b/inc/json.hh
@@ -11,8 +11,8 @@
 
 class json_missing_field : public std::runtime_error
 {
-public:
-    json_missing_field(const std::string &field_name) : std::runtime_error(field_name + " field is missing") {}
+ public:
+    explicit json_missing_field(const std::string &field_name) : std::runtime_error(field_name + " field is missing") {}
 };
 
 class json {

--- a/inc/json.hh
+++ b/inc/json.hh
@@ -25,7 +25,11 @@ class json {
         else
             obj = json_object_new_object();
     }
-    explicit json(json_object *c_obj) : obj(c_obj) {}
+    explicit json(json_object *c_obj) : obj(c_obj) {
+        if (obj) json_object_get(obj);
+        else
+            obj = json_object_new_object();
+    }
     // release reference on underlying json_object*,
     // if this was last reference it will get freed
     ~json() { json_object_put(obj); }

--- a/inc/json.hh
+++ b/inc/json.hh
@@ -9,6 +9,12 @@
 #include <string>
 #include <stdexcept>
 
+class json_missing_field : public std::runtime_error
+{
+public:
+    json_missing_field(const std::string &field_name) : std::runtime_error(field_name + " field is missing") {}
+};
+
 class json {
  public:
     // normally want to take reference on underlying json_object*,
@@ -63,7 +69,7 @@ class json {
         if (!json_object_is_type(obj, json_type_object))
             throw std::runtime_error("Not a hash-type object!");
         json_object *field_obj = json_object_object_get(obj, field_name);
-        if (field_obj == NULL) throw std::runtime_error("No such field!");
+        if (field_obj == NULL) throw json_missing_field(field_name);
         json_object_get(field_obj);
         return json(field_obj);
     }
@@ -72,7 +78,7 @@ class json {
         if (!json_object_is_type(obj, json_type_object))
             throw std::runtime_error("Not a hash-type object!");
         json_object *field_obj = json_object_object_get(obj, field_name);
-        if (field_obj == NULL) throw std::runtime_error("No such field!");
+        if (field_obj == NULL) throw json_missing_field(field_name);
         json_object_get(field_obj);
         return json(field_obj);
     }


### PR DESCRIPTION
* fix json constructor from json_object ptr    
    * if ptr is null, create an empty object
    * if ptr is non-null, take a reference on it so it will not
      get freed until json wrapper object is done with it
* throw custom exception for missing fields