### PR TITLE
new: usr: runtime config of redis-ipc itself

### DIFF
--- a/.github/workflows/choke.yml
+++ b/.github/workflows/choke.yml
@@ -54,3 +54,4 @@ jobs:
     - name: Run tests with valgrind
       run: |
         tox -e grind
+        tox -e tests

--- a/src/redis_ipc.c
+++ b/src/redis_ipc.c
@@ -29,6 +29,7 @@ struct redis_ipc_per_thread
     redisContext *redis_state;  // state for connection to redis server
     const char *redis_socket_path;  // path for connection to redis server
     unsigned int command_ctr;   // counter for number of commands sent by thread
+    int force_quiet;          // force stderr prints off
 };
 
 static __thread struct redis_ipc_per_thread *redis_ipc_info = NULL;
@@ -192,10 +193,7 @@ int redis_ipc_init(const char *this_component, const char *this_thread)
     return RIPC_OK;
 
 redis_ipc_init_failed:
-    if (stderr_debug_is_enabled())
-    {
-        fprintf(stderr, "[ERROR] redis_ipc_init failed for thread %s\n", this_thread);
-    }
+    fprintf(stderr, "[ERROR] redis_ipc_init failed for thread %s\n", this_thread);
     cleanup_per_thread_info(new_info);
     safe_free(new_info);
 
@@ -251,14 +249,18 @@ int redis_ipc_config_settings_writer(const char *writer_component)
     return set_config(SETTINGS_WRITER_FIELD, writer_component);
 }
 
-char * redis_read_hash_field(const char *hash_path, const char *field_name, int force_quiet);
+char * redis_read_hash_field(const char *hash_path, const char *field_name);
 static const char *get_config(const char *field_name)
 {
+    struct redis_ipc_per_thread *thread_info = get_per_thread_info();
     char setting_hash_path[RIPC_MAX_IPC_PATH_LEN];
     const char *lookup = NULL;
 
+    // set flag to disable stderr debugging when looking up internal config settings
+    thread_info->force_quiet = 1;
     ipc_path(setting_hash_path, sizeof(setting_hash_path), RPC_TYPE_SETTING, RIPC_COMPONENT, NULL);
-    lookup = redis_read_hash_field(setting_hash_path, field_name, 1);  // 1=no-stderr-debug
+    lookup = redis_read_hash_field(setting_hash_path, field_name);
+    thread_info->force_quiet = 0;
     return lookup;
 }
 
@@ -272,8 +274,16 @@ int get_debug_verbosity()
 
 int stderr_debug_is_enabled()
 {
+    struct redis_ipc_per_thread *thread_info = get_per_thread_info();
     int stderr_enabled = RIPC_DEFAULT_STDERR;
-    const char *lookup = get_config(STDERR_FIELD);
+    const char *lookup = NULL;
+
+    // prevent infinite recursion: always say "no" while looking up current config
+    if (thread_info->force_quiet == 1)
+        return 0;
+
+    lookup = get_config(STDERR_FIELD);
+
     if (lookup) stderr_enabled = atoi(lookup);
     return stderr_enabled;
 }
@@ -314,17 +324,15 @@ redisReply * validate_redis_reply(redisReply *reply)
 
 // run redis command and return reply object if command succeeds
 //
-// force_quiet=1 disables runtime check for stderr debug setting (prevent infinite recursion)
-//
 // if return value is non-null,
 // caller is responsible for calling freeReplyObject() when done with reply
-redisReply * redis_command(int force_quiet, const char *format, ...)
+redisReply * redis_command(const char *format, ...)
 {
     struct redis_ipc_per_thread *thread_info = get_per_thread_info();
     redisReply *reply = NULL;
     va_list argp;
 
-    if (!force_quiet && stderr_debug_is_enabled())
+    if (stderr_debug_is_enabled())
     {
         va_start(argp, format);
         vfprintf(stderr, format, argp);
@@ -412,7 +420,7 @@ static int redis_push(const char *queue_path, json_object *obj)
     json_text = json_object_to_json_string(obj);
 
     // don't forget to free reply later
-    reply = redis_command(0, "RPUSH %s %s", queue_path, json_text);
+    reply = redis_command("RPUSH %s %s", queue_path, json_text);
 
     if (reply != NULL)
     {
@@ -430,7 +438,7 @@ static json_object * redis_pop(const char *queue_path, unsigned int timeout)
     redisReply *reply = NULL;
 
     // don't forget to free reply later
-    reply = redis_command(0, "BLPOP %s %d", queue_path, timeout);
+    reply = redis_command("BLPOP %s %d", queue_path, timeout);
     if (reply == NULL)
         goto redis_pop_finish;
 
@@ -755,7 +763,7 @@ int redis_write_hash_field(const char *hash_path, const char *field_name,
     int ret = RIPC_FAIL;
 
     // don't forget to free reply later
-    reply = redis_command(0, "HSET %s %s %s", hash_path, field_name, field_value);
+    reply = redis_command("HSET %s %s %s", hash_path, field_name, field_value);
 
     if (reply != NULL)
     {
@@ -827,7 +835,7 @@ json_object * redis_read_hash(const char *hash_path)
     int i = 0;
 
     // don't forget to free reply later
-    reply = redis_command(0, "HGETALL %s", hash_path);
+    reply = redis_command("HGETALL %s", hash_path);
 
     // extract fields from reply object
     //
@@ -911,31 +919,30 @@ redis_ipc_read_status_finish:
     return fields;
 }
 
-// force_quiet=1 disables runtime check for stderr debug setting (prevent infinite recursion)
-char * redis_read_hash_field(const char *hash_path, const char *field_name, int force_quiet)
+char * redis_read_hash_field(const char *hash_path, const char *field_name)
 {
     redisReply *reply = NULL;
     char *field_value = NULL;
 
     // don't forget to free reply later
-    reply = redis_command(force_quiet, "HGET %s %s", hash_path, field_name);
+    reply = redis_command("HGET %s %s", hash_path, field_name);
 
     // extract fields from reply object
     //
     // reply should be a string
     if (reply == NULL)
     {
-        if (!force_quiet && stderr_debug_is_enabled()) fprintf(stderr, "[HASH_FIELD] <null result>\n");
+        if (stderr_debug_is_enabled()) fprintf(stderr, "[HASH_FIELD] <null result>\n");
         goto redis_read_hash_field_finish;
     }
     if (reply->type != REDIS_REPLY_STRING)
     {
-        if (!force_quiet && stderr_debug_is_enabled())
+        if (stderr_debug_is_enabled())
             fprintf(stderr, "[HASH_FIELD] <non-string result type %d>\n", reply->type);
         goto redis_read_hash_field_finish;
     }
     field_value = strdup(reply->str);
-    if (!force_quiet && stderr_debug_is_enabled())
+    if (stderr_debug_is_enabled())
         fprintf(stderr, "[HASH_FIELD] %s='%s'\n", field_name, field_value);
 
 redis_read_hash_field_finish:
@@ -963,7 +970,7 @@ char * redis_ipc_read_setting_field(const char *owner_component, const char *fie
         goto redis_ipc_read_setting_field_finish;
 
     // get all fields of setting hash
-    field_value = redis_read_hash_field(setting_hash_path, field_name, 0);
+    field_value = redis_read_hash_field(setting_hash_path, field_name);
 
 redis_ipc_read_setting_field_finish:
 
@@ -988,7 +995,7 @@ char * redis_ipc_read_status_field(const char *owner_component, const char *fiel
         goto redis_ipc_read_status_field_finish;
 
     // get all fields of status hash
-    field_value = redis_read_hash_field(status_hash_path, field_name, 0);
+    field_value = redis_read_hash_field(status_hash_path, field_name);
 
 redis_ipc_read_status_field_finish:
 
@@ -1011,7 +1018,7 @@ static int redis_publish(const char *channel_path, json_object *obj)
     json_text = json_object_to_json_string(obj);
 
     // don't forget to free reply later
-    reply = redis_command(0, "PUBLISH %s %s", channel_path, json_text);
+    reply = redis_command("PUBLISH %s %s", channel_path, json_text);
 
     if (reply != NULL)
     {
@@ -1134,7 +1141,7 @@ static int redis_subscribe(const char *channel_path)
     int ret = RIPC_FAIL;
 
     // don't forget to free reply later
-    reply = redis_command(0, "PSUBSCRIBE %s", channel_path);
+    reply = redis_command("PSUBSCRIBE %s", channel_path);
 
     if (reply != NULL)
     {
@@ -1236,7 +1243,7 @@ static int redis_unsubscribe(char *channel_path)
     int ret = RIPC_FAIL;
 
     // don't forget to free reply later
-    reply = redis_command(0, "PUNSUBSCRIBE %s", channel_path);
+    reply = redis_command("PUNSUBSCRIBE %s", channel_path);
 
     if (reply != NULL)
     {

--- a/src/redis_ipc.h
+++ b/src/redis_ipc.h
@@ -50,6 +50,19 @@ enum { RIPC_DBG_ERROR,
 #endif
 #define RIPC_SERVER_PATH RIPC_RUNTIME_DIR "/socket"
 
+//*********** defaults for settings that can be optionally configured via functions
+
+// default verbosity level for debug channel messages
+#define RIPC_DEFAULT_VERBOSITY 5
+
+// default stderr debug messages enabled
+#define RIPC_DEFAULT_STDERR 1
+
+// component allowed to write settings (or "*" if any component is allowed)
+#define RIPC_COMPONENT_ANY "*"
+#define RIPC_DEFAULT_SETTINGS_WRITER "db"
+// #define RIPC_DEFAULT_SETTINGS_WRITER RIPC_COMPONENT_ANY
+
 //*************
 // functions
 //*************
@@ -124,7 +137,7 @@ json_object * redis_ipc_receive_command_blocking(const char *subqueue,
 int redis_ipc_send_result(const json_object *completed_command, json_object *result);
 
 
-// A component can only write a setting if it has been authorized by redis_ipc.conf,
+// A component can only write a setting if it has been authorized,
 // but it can read any setting.
 //
 // Each setting is a set of fields that are key-value pairs, where both field name and
@@ -225,6 +238,19 @@ int redis_ipc_unsubscribe_debug(void);
 // should have been subscribed before listening for messages.
 
 json_object * redis_ipc_get_message_blocking(void);
+
+// Functions for configuring behavior of redis-ipc itself
+// see RIPC_DEFAULT_* definitions for default values if not called
+
+// configure verbosity level for debug channel
+int redis_ipc_config_debug_verbosity(int verbosity);
+
+// configure whether debug messages will be shown on stderr
+int redis_ipc_config_stderr_debug(int enable_stderr);
+
+// configure which component will be authorized to write settings
+// (RIPC_COMPONENT_ANY works as wildcard for "any")
+int redis_ipc_config_settings_writer(const char *writer_component);
 
 #ifdef __cplusplus
 }

--- a/src/redis_ipc.h
+++ b/src/redis_ipc.h
@@ -53,10 +53,10 @@ enum { RIPC_DBG_ERROR,
 //*********** defaults for settings that can be optionally configured via functions
 
 // default verbosity level for debug channel messages
-#define RIPC_DEFAULT_VERBOSITY 5
+#define RIPC_DEFAULT_DEBUG_VERBOSITY 5
 
 // default stderr debug messages enabled
-#define RIPC_DEFAULT_STDERR 1
+#define RIPC_DEFAULT_STDERR_DEBUG 1
 
 // component allowed to write settings (or "*" if any component is allowed)
 #define RIPC_COMPONENT_ANY "*"
@@ -87,11 +87,16 @@ enum { RIPC_DBG_ERROR,
 // queue -- and we want same results queues to be re-used if component gets
 // restarted (avoid having to garbage-collect stale, abandoned redis queues)
 //
+// Global redis-ipc settings are normally cached in each thread during
+// init, but threads can explicitly ask for a config relead if desired
+// (to pick up changes some other thread made to global settings).
+//
 // Cleanup is done based on thread ID so that main thread can clean up for
 // terminated threads, as long as it is tracking their IDs. For a
 // single-threaded process, tid == pid.
 
 int redis_ipc_init(const char *this_component, const char *this_thread);
+void redis_ipc_config_load(void);
 int redis_ipc_cleanup(pid_t tid);
 
 

--- a/test/command_result_test.out
+++ b/test/command_result_test.out
@@ -1,8 +1,9 @@
-# sample output from command_result_test
-BLPOP queues.commands.streaming.video 0
-RPUSH queues.commands.streaming.video { "method": "control_recording", "params": "start", "results_queue": "queues.results.web.requestor", "command_id": "web-requestor-20157-0", "timestamp": "1401058409.891079", "component": "web", "thread": "requestor", "tid": 20157 }
-BLPOP queues.results.web.requestor 10
-[ENTRY:queues.commands.streaming.video] { "method": "control_recording", "params": "start", "results_queue": "queues.results.web.requestor", "command_id": "web-requestor-20157-0", "timestamp": "1401058409.891079", "component": "web", "thread": "requestor", "tid": 20157 }
-RPUSH queues.results.web.requestor { "code": -2, "message": "Next time, say 'please'", "command_id": "web-requestor-20157-0", "timestamp": "1401058409.892059", "component": "streaming", "thread": "recorder", "tid": 20158 }
-[ENTRY:queues.results.web.requestor] { "code": -2, "message": "Next time, say 'please'", "command_id": "web-requestor-20157-0", "timestamp": "1401058409.892059", "component": "streaming", "thread": "recorder", "tid": 20158 }
-Received result: { "code": -2, "message": "Next time, say 'please'", "command_id": "web-requestor-20157-0", "timestamp": "1401058409.892059", "component": "streaming", "thread": "recorder", "tid": 20158 }
+(streaming) CONFIG SET notify-keyspace-events Kh
+(streaming) BLPOP queues.commands.streaming.video 0
+(web) CONFIG SET notify-keyspace-events Kh
+(web) RPUSH queues.commands.streaming.video { "method": "control_recording", "params": "start", "results_queue": "queues.results.web.requestor", "command_id": "web-requestor-18824-0", "timestamp": "1668592134.787857", "component": "web", "thread": "requestor", "tid": 18824 }
+(web) BLPOP queues.results.web.requestor 10
+(streaming) [ENTRY:queues.commands.streaming.video] { "method": "control_recording", "params": "start", "results_queue": "queues.results.web.requestor", "command_id": "web-requestor-18824-0", "timestamp": "1668592134.787857", "component": "web", "thread": "requestor", "tid": 18824 }
+(streaming) RPUSH queues.results.web.requestor { "code": -2, "message": "Next time, say 'please'", "command_id": "web-requestor-18824-0", "timestamp": "1668592134.788300", "component": "streaming", "thread": "recorder", "tid": 18825 }
+(web) [ENTRY:queues.results.web.requestor] { "code": -2, "message": "Next time, say 'please'", "command_id": "web-requestor-18824-0", "timestamp": "1668592134.788300", "component": "streaming", "thread": "recorder", "tid": 18825 }
+Received result: { "code": -2, "message": "Next time, say 'please'", "command_id": "web-requestor-18824-0", "timestamp": "1668592134.788300", "component": "streaming", "thread": "recorder", "tid": 18825 }

--- a/test/multithread_test.out
+++ b/test/multithread_test.out
@@ -1,5 +1,6 @@
-# sample output from multithread_test
-PUBLISH channel.debug.printer { "message": "printer starting to smoke", "level": 1, "channel": "channel.debug.printer", "timestamp": "1401058399.161286", "component": "printer", "thread": "monitor", "tid": 20152 }
-PUBLISH channel.debug.button { "message": "NO don't press that button...", "level": 1, "channel": "channel.debug.button", "timestamp": "1401058399.161285", "component": "button", "thread": "watcher", "tid": 20153 }
-PUBLISH channel.debug.printer { "message": "printer on fire!!", "level": 0, "channel": "channel.debug.printer", "timestamp": "1401058399.161965", "component": "printer", "thread": "monitor", "tid": 20152 }
-PUBLISH channel.debug.button { "message": "I told you not to press it!!", "level": 0, "channel": "channel.debug.button", "timestamp": "1401058399.162194", "component": "button", "thread": "watcher", "tid": 20153 }
+(button) CONFIG SET notify-keyspace-events Kh
+(printer) CONFIG SET notify-keyspace-events Kh
+(button) PUBLISH channel.debug.button { "message": "NO don't press that button...", "level": 1, "channel": "channel.debug.button", "timestamp": "1668592241.554110", "component": "button", "thread": "watcher", "tid": 19190 }
+(printer) PUBLISH channel.debug.printer { "message": "printer starting to smoke", "level": 1, "channel": "channel.debug.printer", "timestamp": "1668592241.554110", "component": "printer", "thread": "monitor", "tid": 19189 }
+(printer) PUBLISH channel.debug.printer { "message": "printer on fire!!", "level": 0, "channel": "channel.debug.printer", "timestamp": "1668592241.554176", "component": "printer", "thread": "monitor", "tid": 19189 }
+(button) PUBLISH channel.debug.button { "message": "I told you not to press it!!", "level": 0, "channel": "channel.debug.button", "timestamp": "1668592241.554177", "component": "button", "thread": "watcher", "tid": 19190 }

--- a/test/pub_sub_test.c
+++ b/test/pub_sub_test.c
@@ -7,6 +7,7 @@ void spawn_listener_process(void)
 {
   json_object *message;
   pid_t pid = fork();
+  int i;
 
   // parent waits for child to start listening, then returns
   if (pid > 0)
@@ -21,11 +22,11 @@ void spawn_listener_process(void)
   redis_ipc_subscribe_events("printer", NULL);
   redis_ipc_subscribe_debug("printer");
 
-  message = redis_ipc_get_message_blocking();
-  json_object_put(message);
-
-  message = redis_ipc_get_message_blocking();
-  json_object_put(message);
+  for (i = 0; i < 4; i++)
+  {
+      message = redis_ipc_get_message_blocking();
+      json_object_put(message);
+  }
 
   redis_ipc_unsubscribe_events();
   redis_ipc_unsubscribe_debug();

--- a/test/pub_sub_test.out
+++ b/test/pub_sub_test.out
@@ -1,21 +1,15 @@
-(web) HGET settings.redis-ipc stderr_debug
-(web) [HASH_FIELD] <non-string result type 4>
-(web) HGET settings.redis-ipc settings_writer
-(web) [HASH_FIELD] <non-string result type 4>
+(web) CONFIG SET notify-keyspace-events Kh
 (web) PSUBSCRIBE channel.events.printer*
 (web) PSUBSCRIBE channel.debug.printer
-(printer) HGET settings.redis-ipc stderr_debug
-(printer) [HASH_FIELD] <non-string result type 4>
-(printer) HGET settings.redis-ipc settings_writer
-(printer) [HASH_FIELD] <non-string result type 4>
-(printer) PUBLISH channel.debug.printer { "message": "printer starting to smoke", "level": 1, "channel": "channel.debug.printer", "timestamp": "1668565641.611715", "component": "printer", "thread": "monitor", "tid": 25068 }
-(printer) PUBLISH channel.debug.printer { "message": "printer on fire!!", "level": 0, "channel": "channel.debug.printer", "timestamp": "1668565641.611806", "component": "printer", "thread": "monitor", "tid": 25068 }
-(web) [MESSAGE] { "message": "printer starting to smoke", "level": 1, "channel": "channel.debug.printer", "timestamp": "1668565641.611715", "component": "printer", "thread": "monitor", "tid": 25068 }
-(printer) PUBLISH channel.events.printer.state { "severity": "warning", "message": "printer is down for the count", "channel": "channel.events.printer.state", "timestamp": "1668565641.611901", "component": "printer", "thread": "monitor", "tid": 25068 }
-(web) [MESSAGE] { "message": "printer on fire!!", "level": 0, "channel": "channel.debug.printer", "timestamp": "1668565641.611806", "component": "printer", "thread": "monitor", "tid": 25068 }
-(web) [MESSAGE] { "severity": "warning", "message": "printer is down for the count", "channel": "channel.events.printer.state", "timestamp": "1668565641.611901", "component": "printer", "thread": "monitor", "tid": 25068 }
-(printer) PUBLISH channel.events.printer.media { "severity": "alert", "message": "there went our expensive paper", "pages_remaining": 0, "channel": "channel.events.printer.media", "timestamp": "1668565641.611992", "component": "printer", "thread": "monitor", "tid": 25068 }
-(printer) PUBLISH channel.events.printer { "severity": "info", "message": "save trees, go digital", "channel": "channel.events.printer", "timestamp": "1668565641.612066", "component": "printer", "thread": "monitor", "tid": 25068 }
-(web) [MESSAGE] { "severity": "alert", "message": "there went our expensive paper", "pages_remaining": 0, "channel": "channel.events.printer.media", "timestamp": "1668565641.611992", "component": "printer", "thread": "monitor", "tid": 25068 }
+(printer) CONFIG SET notify-keyspace-events Kh
+(printer) PUBLISH channel.debug.printer { "message": "printer starting to smoke", "level": 1, "channel": "channel.debug.printer", "timestamp": "1668592265.505625", "component": "printer", "thread": "monitor", "tid": 19230 }
+(printer) PUBLISH channel.debug.printer { "message": "printer on fire!!", "level": 0, "channel": "channel.debug.printer", "timestamp": "1668592265.505687", "component": "printer", "thread": "monitor", "tid": 19230 }
+(web) [MESSAGE] { "message": "printer starting to smoke", "level": 1, "channel": "channel.debug.printer", "timestamp": "1668592265.505625", "component": "printer", "thread": "monitor", "tid": 19230 }
+(printer) PUBLISH channel.events.printer.state { "severity": "warning", "message": "printer is down for the count", "channel": "channel.events.printer.state", "timestamp": "1668592265.505756", "component": "printer", "thread": "monitor", "tid": 19230 }
+(printer) (web) PUBLISH channel.events.printer.media { "severity": "alert", "message": "there went our expensive paper", "pages_remaining": 0, "channel": "channel.events.printer.media", "timestamp": "1668592265.505815", "component": "printer", "thread": "monitor", "tid": 19230 }[MESSAGE] { "message": "printer on fire!!", "level": 0, "channel": "channel.debug.printer", "timestamp": "1668592265.505687", "component": "printer", "thread": "monitor", "tid": 19230 }
+
+(web) [MESSAGE] { "severity": "warning", "message": "printer is down for the count", "channel": "channel.events.printer.state", "timestamp": "1668592265.505756", "component": "printer", "thread": "monitor", "tid": 19230 }
+(printer) PUBLISH channel.events.printer { "severity": "info", "message": "save trees, go digital", "channel": "channel.events.printer", "timestamp": "1668592265.505935", "component": "printer", "thread": "monitor", "tid": 19230 }
+(web) [MESSAGE] { "severity": "alert", "message": "there went our expensive paper", "pages_remaining": 0, "channel": "channel.events.printer.media", "timestamp": "1668592265.505815", "component": "printer", "thread": "monitor", "tid": 19230 }
 (web) PUNSUBSCRIBE channel.events.*
 (web) PUNSUBSCRIBE channel.debug.*

--- a/test/pub_sub_test.out
+++ b/test/pub_sub_test.out
@@ -1,9 +1,13 @@
-# sample output from pub_sub_test
-PSUBSCRIBE channel.events.printer*
-PSUBSCRIBE channel.debug.printer
-PUBLISH channel.debug.printer { "message": "printer starting to smoke", "level": 1, "channel": "channel.debug.printer", "timestamp": "1401058419.059077", "component": "printer", "thread": "monitor", "tid": 20162 }
-[MESSAGE] { "message": "printer starting to smoke", "level": 1, "channel": "channel.debug.printer", "timestamp": "1401058419.059077", "component": "printer", "thread": "monitor", "tid": 20162 }
-PUBLISH channel.events.printer.state { "severity": "warning", "message": "printer is down for the count", "channel": "channel.events.printer.state", "timestamp": "1401058419.060264", "component": "printer", "thread": "monitor", "tid": 20162 }[MESSAGE] { "message": "printer on fire!!", "level": 0, "channel": "channel.debug.printer", "timestamp": "1401058419.059784", "component": "printer", "thread": "monitor", "tid": 20162 }
-PUNSUBSCRIBE channel.events.*
-PUBLISH channel.events.printer.media { "severity": "alert", "message": "there went our expensive paper", "pages_remaining": 0, "channel": "channel.events.printer.media", "timestamp": "1401058419.060719", "component": "printer", "thread": "monitor", "tid": 20162 }PUNSUBSCRIBE channel.debug.*
-PUBLISH channel.events.printer { "severity": "info", "message": "save trees, go digital", "channel": "channel.events.printer", "timestamp": "1401058419.061587", "component": "printer", "thread": "monitor", "tid": 20162 }
+(web) PSUBSCRIBE channel.events.printer*
+(web) PSUBSCRIBE channel.debug.printer
+(printer) PUBLISH channel.debug.printer { "message": "printer starting to smoke", "level": 1, "channel": "channel.debug.printer", "timestamp": "1668556824.464753", "component": "printer", "thread": "monitor", "tid": 15142 }
+(web) (printer) [MESSAGE] { "message": "printer starting to smoke", "level": 1, "channel": "channel.debug.printer", "timestamp": "1668556824.464753", "component": "printer", "thread": "monitor", "tid": 15142 }PUBLISH channel.debug.printer { "message": "printer on fire!!", "level": 0, "channel": "channel.debug.printer", "timestamp": "1668556824.465350", "component": "printer", "thread": "monitor", "tid": 15142 }
+
+(printer) PUBLISH channel.events.printer.state { "severity": "warning", "message": "printer is down for the count", "channel": "channel.events.printer.state", "timestamp": "1668556824.465616", "component": "printer", "thread": "monitor", "tid": 15142 }
+(web) [MESSAGE] { "message": "printer on fire!!", "level": 0, "channel": "channel.debug.printer", "timestamp": "1668556824.465350", "component": "printer", "thread": "monitor", "tid": 15142 }
+(web) PUNSUBSCRIBE channel.events.*
+(printer) PUBLISH channel.events.printer.media { "severity": "alert", "message": "there went our expensive paper", "pages_remaining": 0, "channel": "channel.events.printer.media", "timestamp": "1668556824.465889", "component": "printer", "thread": "monitor", "tid": 15142 }
+(web) [ERROR] command failed: ERR only (P)SUBSCRIBE / (P)UNSUBSCRIBE / PING / QUIT allowed in this context
+(web) (printer) PUNSUBSCRIBE channel.debug.*PUBLISH channel.events.printer { "severity": "info", "message": "save trees, go digital", "channel": "channel.events.printer", "timestamp": "1668556824.466072", "component": "printer", "thread": "monitor", "tid": 15142 }
+
+(web) [ERROR] command failed: ERR only (P)SUBSCRIBE / (P)UNSUBSCRIBE / PING / QUIT allowed in this context

--- a/test/pub_sub_test.out
+++ b/test/pub_sub_test.out
@@ -1,13 +1,21 @@
+(web) HGET settings.redis-ipc stderr_debug
+(web) [HASH_FIELD] <non-string result type 4>
+(web) HGET settings.redis-ipc settings_writer
+(web) [HASH_FIELD] <non-string result type 4>
 (web) PSUBSCRIBE channel.events.printer*
 (web) PSUBSCRIBE channel.debug.printer
-(printer) PUBLISH channel.debug.printer { "message": "printer starting to smoke", "level": 1, "channel": "channel.debug.printer", "timestamp": "1668556824.464753", "component": "printer", "thread": "monitor", "tid": 15142 }
-(web) (printer) [MESSAGE] { "message": "printer starting to smoke", "level": 1, "channel": "channel.debug.printer", "timestamp": "1668556824.464753", "component": "printer", "thread": "monitor", "tid": 15142 }PUBLISH channel.debug.printer { "message": "printer on fire!!", "level": 0, "channel": "channel.debug.printer", "timestamp": "1668556824.465350", "component": "printer", "thread": "monitor", "tid": 15142 }
-
-(printer) PUBLISH channel.events.printer.state { "severity": "warning", "message": "printer is down for the count", "channel": "channel.events.printer.state", "timestamp": "1668556824.465616", "component": "printer", "thread": "monitor", "tid": 15142 }
-(web) [MESSAGE] { "message": "printer on fire!!", "level": 0, "channel": "channel.debug.printer", "timestamp": "1668556824.465350", "component": "printer", "thread": "monitor", "tid": 15142 }
+(printer) HGET settings.redis-ipc stderr_debug
+(printer) [HASH_FIELD] <non-string result type 4>
+(printer) HGET settings.redis-ipc settings_writer
+(printer) [HASH_FIELD] <non-string result type 4>
+(printer) PUBLISH channel.debug.printer { "message": "printer starting to smoke", "level": 1, "channel": "channel.debug.printer", "timestamp": "1668565641.611715", "component": "printer", "thread": "monitor", "tid": 25068 }
+(printer) PUBLISH channel.debug.printer { "message": "printer on fire!!", "level": 0, "channel": "channel.debug.printer", "timestamp": "1668565641.611806", "component": "printer", "thread": "monitor", "tid": 25068 }
+(web) [MESSAGE] { "message": "printer starting to smoke", "level": 1, "channel": "channel.debug.printer", "timestamp": "1668565641.611715", "component": "printer", "thread": "monitor", "tid": 25068 }
+(printer) PUBLISH channel.events.printer.state { "severity": "warning", "message": "printer is down for the count", "channel": "channel.events.printer.state", "timestamp": "1668565641.611901", "component": "printer", "thread": "monitor", "tid": 25068 }
+(web) [MESSAGE] { "message": "printer on fire!!", "level": 0, "channel": "channel.debug.printer", "timestamp": "1668565641.611806", "component": "printer", "thread": "monitor", "tid": 25068 }
+(web) [MESSAGE] { "severity": "warning", "message": "printer is down for the count", "channel": "channel.events.printer.state", "timestamp": "1668565641.611901", "component": "printer", "thread": "monitor", "tid": 25068 }
+(printer) PUBLISH channel.events.printer.media { "severity": "alert", "message": "there went our expensive paper", "pages_remaining": 0, "channel": "channel.events.printer.media", "timestamp": "1668565641.611992", "component": "printer", "thread": "monitor", "tid": 25068 }
+(printer) PUBLISH channel.events.printer { "severity": "info", "message": "save trees, go digital", "channel": "channel.events.printer", "timestamp": "1668565641.612066", "component": "printer", "thread": "monitor", "tid": 25068 }
+(web) [MESSAGE] { "severity": "alert", "message": "there went our expensive paper", "pages_remaining": 0, "channel": "channel.events.printer.media", "timestamp": "1668565641.611992", "component": "printer", "thread": "monitor", "tid": 25068 }
 (web) PUNSUBSCRIBE channel.events.*
-(printer) PUBLISH channel.events.printer.media { "severity": "alert", "message": "there went our expensive paper", "pages_remaining": 0, "channel": "channel.events.printer.media", "timestamp": "1668556824.465889", "component": "printer", "thread": "monitor", "tid": 15142 }
-(web) [ERROR] command failed: ERR only (P)SUBSCRIBE / (P)UNSUBSCRIBE / PING / QUIT allowed in this context
-(web) (printer) PUNSUBSCRIBE channel.debug.*PUBLISH channel.events.printer { "severity": "info", "message": "save trees, go digital", "channel": "channel.events.printer", "timestamp": "1668556824.466072", "component": "printer", "thread": "monitor", "tid": 15142 }
-
-(web) [ERROR] command failed: ERR only (P)SUBSCRIBE / (P)UNSUBSCRIBE / PING / QUIT allowed in this context
+(web) PUNSUBSCRIBE channel.debug.*

--- a/test/settings_status_test.c
+++ b/test/settings_status_test.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include <unistd.h>
 #include "redis_ipc.h"
 
@@ -20,14 +21,25 @@ int main(int argc, char **argv)
                          json_object_new_string("no way"));
   // this should fail, component is not authorized to write settings
   // (not even its own)
+  redis_ipc_config_settings_writer("db");
+  fprintf(stderr, "** This attempt to write settings should fail...\n");
   redis_ipc_write_setting("session", setting);
   json_object_put(setting);
+  fprintf(stderr, "** This attempt to write single setting should fail...\n");
   redis_ipc_write_setting_field("session", "location", "right here");
 
   // should come back empty since above write failed
   setting = redis_ipc_read_setting("session");
   json_object_put(setting);
   redis_ipc_read_setting_field("session", "location");
+
+  // authorize this component to write settings and try again
+  redis_ipc_config_settings_writer("session");
+  fprintf(stderr, "** This attempt to write single setting should work...\n");
+  redis_ipc_write_setting_field("session", "location", "still right here");
+
+  // put back to "db" as authorized component
+  redis_ipc_config_settings_writer("db");
 
   redis_ipc_cleanup(getpid());
 
@@ -36,6 +48,7 @@ int main(int argc, char **argv)
   status = redis_ipc_read_status("session");
   json_object_put(status);
 
+  fprintf(stderr, "** This attempt to write settings should work...\n");
   setting = json_object_new_object();
   json_object_object_add(setting, "num_copies",
                          json_object_new_string("until ink runs out"));
@@ -44,11 +57,18 @@ int main(int argc, char **argv)
   redis_ipc_write_setting("printer", setting);
   json_object_put(setting);
 
+  fprintf(stderr, "** This attempt to write single setting should work...\n");
   redis_ipc_write_setting_field("printer", "contrast", "none");
 
   setting = redis_ipc_read_setting("printer");
-  redis_ipc_read_setting_field("printer", "paper_type");
   json_object_put(setting);
+
+  setting = redis_ipc_config_stderr_debug(0);
+  fprintf(stderr, "** This attempt to read single setting should *not* print debug...\n");
+  redis_ipc_read_setting_field("printer", "paper_type");
+  setting = redis_ipc_config_stderr_debug(1);
+  fprintf(stderr, "** This attempt to read single setting *should* print debug...\n");
+  redis_ipc_read_setting_field("printer", "paper_type");
 
   redis_ipc_cleanup(getpid());
 

--- a/test/settings_status_test.out
+++ b/test/settings_status_test.out
@@ -1,4 +1,4 @@
-(session) HMSET status.session open until closed procedure complicated 
+(session) HMSET status.session open until closed procedure complicated
 (session) HSET settings.redis-ipc settings-writer db
 ** This attempt to write settings should fail...
 (session) [ERROR] component session is not authorized to write settings
@@ -15,7 +15,7 @@
 (db) HGETALL status.session
 (db) [HASH] open='until closed' procedure='complicated'
 ** This attempt to write settings should work...
-(db) HMSET settings.printer num_copies until ink runs out paper_type wrinkled 
+(db) HMSET settings.printer num_copies until ink runs out paper_type wrinkled
 ** This attempt to write single setting should work...
 (db) HSET settings.printer contrast none
 (db) HGETALL settings.printer

--- a/test/settings_status_test.out
+++ b/test/settings_status_test.out
@@ -1,27 +1,27 @@
-HMSET status.session open until closed procedure complicated 
-HSET settings.redis-ipc settings-writer db
+(session) HMSET status.session open until closed procedure complicated 
+(session) HSET settings.redis-ipc settings-writer db
 ** This attempt to write settings should fail...
-[ERROR] component session is not authorized to write settings
+(session) [ERROR] component session is not authorized to write settings
 ** This attempt to write single setting should fail...
-[ERROR] component session is not authorized to write settings
-HGETALL settings.session
-[HASH] location='still right here'
-HGET settings.session location
-[HASH_FIELD] location='still right here'
-HSET settings.redis-ipc settings-writer session
+(session) [ERROR] component session is not authorized to write settings
+(session) HGETALL settings.session
+(session) [HASH] location='still right here'
+(session) HGET settings.session location
+(session) [HASH_FIELD] location='still right here'
+(session) HSET settings.redis-ipc settings-writer session
 ** This attempt to write single setting should work...
-HSET settings.session location still right here
-HSET settings.redis-ipc settings-writer db
-HGETALL status.session
-[HASH] open='until closed' procedure='complicated'
+(session) HSET settings.session location still right here
+(session) HSET settings.redis-ipc settings-writer db
+(db) HGETALL status.session
+(db) [HASH] open='until closed' procedure='complicated'
 ** This attempt to write settings should work...
-HMSET settings.printer num_copies until ink runs out paper_type wrinkled 
+(db) HMSET settings.printer num_copies until ink runs out paper_type wrinkled 
 ** This attempt to write single setting should work...
-HSET settings.printer contrast none
-HGETALL settings.printer
-[HASH] num_copies='until ink runs out' paper_type='wrinkled' contrast='none'
-HSET settings.redis-ipc stderr 0
+(db) HSET settings.printer contrast none
+(db) HGETALL settings.printer
+(db) [HASH] num_copies='until ink runs out' paper_type='wrinkled' contrast='none'
+(db) HSET settings.redis-ipc stderr 0
 ** This attempt to read single setting should *not* print debug...
 ** This attempt to read single setting *should* print debug...
-HGET settings.printer paper_type
-[HASH_FIELD] paper_type='wrinkled'
+(db) HGET settings.printer paper_type
+(db) [HASH_FIELD] paper_type='wrinkled'

--- a/test/settings_status_test.out
+++ b/test/settings_status_test.out
@@ -1,14 +1,27 @@
-# sample output from settings_status_test
-HMSET status.session open until closed procedure complicated
+HMSET status.session open until closed procedure complicated 
+HSET settings.redis-ipc settings-writer db
+** This attempt to write settings should fail...
+[ERROR] component session is not authorized to write settings
+** This attempt to write single setting should fail...
+[ERROR] component session is not authorized to write settings
 HGETALL settings.session
-[HASH]
+[HASH] location='still right here'
 HGET settings.session location
-[HASH_FIELD] <non-string result type 4>
+[HASH_FIELD] location='still right here'
+HSET settings.redis-ipc settings-writer session
+** This attempt to write single setting should work...
+HSET settings.session location still right here
+HSET settings.redis-ipc settings-writer db
 HGETALL status.session
 [HASH] open='until closed' procedure='complicated'
-HMSET settings.printer num_copies until ink runs out paper_type wrinkled
+** This attempt to write settings should work...
+HMSET settings.printer num_copies until ink runs out paper_type wrinkled 
+** This attempt to write single setting should work...
 HSET settings.printer contrast none
 HGETALL settings.printer
 [HASH] num_copies='until ink runs out' paper_type='wrinkled' contrast='none'
+HSET settings.redis-ipc stderr 0
+** This attempt to read single setting should *not* print debug...
+** This attempt to read single setting *should* print debug...
 HGET settings.printer paper_type
 [HASH_FIELD] paper_type='wrinkled'

--- a/test/settings_status_test.out
+++ b/test/settings_status_test.out
@@ -1,26 +1,28 @@
-(session) HMSET status.session open until closed procedure complicated
-(session) HSET settings.redis-ipc settings-writer db
+(session) CONFIG SET notify-keyspace-events Kh
+(session) HMSET status.session open until closed procedure complicated 
+(session) HSET settings.redis-ipc settings_writer db
 ** This attempt to write settings should fail...
 (session) [ERROR] component session is not authorized to write settings
 ** This attempt to write single setting should fail...
 (session) [ERROR] component session is not authorized to write settings
 (session) HGETALL settings.session
-(session) [HASH] location='still right here'
+(session) [HASH]
 (session) HGET settings.session location
-(session) [HASH_FIELD] location='still right here'
-(session) HSET settings.redis-ipc settings-writer session
+(session) [HASH_FIELD] <non-string result type 4>
+(session) HSET settings.redis-ipc settings_writer session
 ** This attempt to write single setting should work...
 (session) HSET settings.session location still right here
-(session) HSET settings.redis-ipc settings-writer db
+(session) HSET settings.redis-ipc settings_writer db
+(db) CONFIG SET notify-keyspace-events Kh
 (db) HGETALL status.session
 (db) [HASH] open='until closed' procedure='complicated'
 ** This attempt to write settings should work...
-(db) HMSET settings.printer num_copies until ink runs out paper_type wrinkled
+(db) HMSET settings.printer num_copies until ink runs out paper_type wrinkled 
 ** This attempt to write single setting should work...
 (db) HSET settings.printer contrast none
 (db) HGETALL settings.printer
 (db) [HASH] num_copies='until ink runs out' paper_type='wrinkled' contrast='none'
-(db) HSET settings.redis-ipc stderr 0
+(db) HSET settings.redis-ipc stderr_debug 0
 ** This attempt to read single setting should *not* print debug...
 ** This attempt to read single setting *should* print debug...
 (db) HGET settings.printer paper_type

--- a/tox.ini
+++ b/tox.ini
@@ -60,7 +60,7 @@ commands =
     tests: bash -c 'cmake -DWITH_COVERAGE=1 -DCMAKE_BUILD_TYPE=Debug ..'
     grind: bash -c 'cmake -DRIPC_BUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug ..'
     {tests,clang,grind}: bash -c 'cmake --build . -j $(nproc)'
-    {tests,grind}: bash -c 'ctest -V --test-dir ./'
+    tests: bash -c 'ctest -V --test-dir ./'
     clang: bash -c 'cmake --build . --target coverage'
     lcov: lcov_cobertura build/coverage/lcov.info --base-dir {toxinidir} --output coverage.xml
     lint: bash -c 'cpplint --output=gsed {toxinidir}/src/* {toxinidir}/inc/*'


### PR DESCRIPTION
Functions for configuring behavior of redis-ipc itself see RIPC_DEFAULT_* definitions for default values if not called

// configure verbosity level for debug channel
int redis_ipc_config_debug_verbosity(int verbosity);

// configure whether debug messages will be shown on stderr int redis_ipc_config_stderr_debug(int enable_stderr);

// configure which component will be authorized to write settings // (RIPC_COMPONENT_ANY works as wildcard for "any") int redis_ipc_config_settings_writer(const char *writer_component);