### PR TITLE
json.hh: exception for constructing from invalid text

### DIFF
--- a/inc/json.hh
+++ b/inc/json.hh
@@ -9,6 +9,12 @@
 #include <string>
 #include <stdexcept>
 
+class json_parse_failure : public std::runtime_error
+{
+ public:
+    explicit json_parse_failure(const std::string &bad_text) : std::runtime_error("failed to parse text=" + bad_text) {}
+};
+
 class json_missing_field : public std::runtime_error
 {
  public:
@@ -28,8 +34,7 @@ class json {
     json(const json &copy) { obj = copy.obj; json_object_get(obj); }
     explicit json(const char *json_text) {
         if (json_text) obj = json_tokener_parse(json_text);
-        else
-            obj = json_object_new_object();
+        if (obj == NULL) throw json_parse_failure(json_text);
     }
     explicit json(json_object *c_obj) : obj(c_obj) {
         if (obj) json_object_get(obj);

--- a/test/json_test.cpp
+++ b/test/json_test.cpp
@@ -65,4 +65,21 @@ int main(int argc, char **argv)
         cout << "OK these objects don't match" << endl;
     else
         cout << "ERROR these objects were not supposed to match" << endl;
+
+    bool parse_failed = false;
+    try
+    {
+        json bork("\"whatisthis");
+    }
+    catch (json_parse_failure &exc)
+    {
+        parse_failed = true;
+        cout << "OK got exception for invalid JSON text: " << exc.what() << endl;
+    }
+
+    if (!parse_failed)
+    {
+        cout << "ERROR invalid JSON text was not noticed" << endl;
+    }
+
 }

--- a/test/json_test.out
+++ b/test/json_test.out
@@ -18,3 +18,4 @@ OK these objects match
 OK these objects match
 OK these objects don't match
 OK these objects don't match
+OK got exception for invalid JSON text: failed to parse text="whatisthis


### PR DESCRIPTION
The intention for json class is that wrapped json-c objects will never be null, but this was able to be violated by the constructor that has text string as argument. When the text string was not valid JSON, the obj pointer turned out NULL.

Throw an exception instead, so this parsing failure case will need to be handled right away instead of causing bugs later from a NULL pointer.