### PR TITLE
fix: usr: clean up memory leaks found with valgrind

### DIFF
--- a/inc/json.hh
+++ b/inc/json.hh
@@ -106,7 +106,6 @@ class json {
             throw std::runtime_error("Not a hash-type object!");
         json_object *field_obj = json_object_object_get(obj, field_name);
         if (field_obj == NULL) throw json_missing_field(field_name);
-        json_object_get(field_obj);
         return json(field_obj);
     }
 
@@ -115,7 +114,6 @@ class json {
             throw std::runtime_error("Not a hash-type object!");
         json_object *field_obj = json_object_object_get(obj, field_name);
         if (field_obj == NULL) throw json_missing_field(field_name);
-        json_object_get(field_obj);
         return json(field_obj);
     }
 
@@ -154,11 +152,12 @@ class json {
         json_object_object_add(obj, field_name, bool_obj);
     }
 
-    // caller must make sure the 'value' object stays alive while it
-    // is still used as a field
     void set_field(const char *field_name, const json &value) {
         if (!json_object_is_type(obj, json_type_object))
             throw std::runtime_error("Not a hash-type object!");
+        // take extra reference so that value object will not be destroyed
+        // just because this object gets destroyed (add does not bump reference count)
+        json_object_get(value.obj);
         json_object_object_add(obj, field_name, value.obj);
     }
 
@@ -167,7 +166,6 @@ class json {
             throw std::runtime_error("Not an array-type object!");
         json_object *element_obj = json_object_array_get_idx(obj, idx);
         if (element_obj == NULL) throw std::runtime_error("No such element!");
-        json_object_get(element_obj);
         return json(element_obj);
     }
 
@@ -176,7 +174,6 @@ class json {
             throw std::runtime_error("Not an array-type object!");
         json_object *element_obj = json_object_array_get_idx(obj, idx);
         if (element_obj == NULL) throw std::runtime_error("No such element!");
-        json_object_get(element_obj);
         return json(element_obj);
     }
 

--- a/test/json_test.cpp
+++ b/test/json_test.cpp
@@ -10,8 +10,6 @@ int main(int argc, char **argv)
 
     json snook(hum), took(de);
     // snook and took should be holding references now, let go of original refs
-    json_object_put(hum);
-    json_object_put(de);
     took.set_field("baggins", 9999);
     took.set_field("bilbo", "hungry");
     snook.set_field("betook", took);

--- a/test/json_test.cpp
+++ b/test/json_test.cpp
@@ -9,6 +9,9 @@ int main(int argc, char **argv)
     json_object *de = json_object_new_object();
 
     json snook(hum), took(de);
+    // snook and took should be holding references now, let go of original refs
+    json_object_put(hum);
+    json_object_put(de);
     took.set_field("baggins", 9999);
     took.set_field("bilbo", "hungry");
     snook.set_field("betook", took);

--- a/test/settings_status_test.c
+++ b/test/settings_status_test.c
@@ -6,6 +6,7 @@ int main(int argc, char **argv)
 {
   json_object *setting = NULL;
   json_object *status = NULL;
+  char *field = NULL;
 
   redis_ipc_init("session", "main");
 
@@ -15,6 +16,7 @@ int main(int argc, char **argv)
   json_object_object_add(status, "procedure",
                          json_object_new_string("complicated"));
   redis_ipc_write_status(status);
+  json_object_put(status);
 
   setting = json_object_new_object();
   json_object_object_add(setting, "auto_finalize",
@@ -31,7 +33,8 @@ int main(int argc, char **argv)
   // should come back empty since above write failed
   setting = redis_ipc_read_setting("session");
   json_object_put(setting);
-  redis_ipc_read_setting_field("session", "location");
+  field = redis_ipc_read_setting_field("session", "location");
+  if (field) free(field);
 
   // authorize this component to write settings and try again
   redis_ipc_config_settings_writer("session");
@@ -63,12 +66,14 @@ int main(int argc, char **argv)
   setting = redis_ipc_read_setting("printer");
   json_object_put(setting);
 
-  setting = redis_ipc_config_stderr_debug(0);
+  redis_ipc_config_stderr_debug(0);
   fprintf(stderr, "** This attempt to read single setting should *not* print debug...\n");
-  redis_ipc_read_setting_field("printer", "paper_type");
-  setting = redis_ipc_config_stderr_debug(1);
+  field = redis_ipc_read_setting_field("printer", "paper_type");
+  if (field) free(field);
+  redis_ipc_config_stderr_debug(1);
   fprintf(stderr, "** This attempt to read single setting *should* print debug...\n");
-  redis_ipc_read_setting_field("printer", "paper_type");
+  field = redis_ipc_read_setting_field("printer", "paper_type");
+  if (field) free(field);
 
   redis_ipc_cleanup(getpid());
 


### PR DESCRIPTION
Get the test apps to pass 'valgrind --leak-check=full' without any leaks detected.

* redis_ipc.c - add some missing frees

* json.hh - fix reference management
  * get_field(): the json constructor of return value will automatically take a reference on the wrapped json_object, so don't need to manually bump reference count with json_object_get()
  * set_field() with json value: *do* manually take reference so the value object passed in will not be destroyed when the newly assigned parent object gets destroyed, since "add" does not bump reference count but later parent will try to clean it up