### PR TITLE
new: user: add support for per-component 'active_state'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,7 @@ to implement the following IPC mechanisms:
 * command queues
 * settings
 * status
+* state
 * event channels
 
 "But, but... redis for *embedded* applications??"
@@ -461,16 +462,17 @@ As mentioned in the intro, redis-ipc implements the following mechanisms:
 * command queues
 * settings
 * status
+* state
 * event channels
 
-Command queues are a method for any component to request an action from
+**Command queues** are a method for any component to request an action from
 another component, and receive a result after the command has been processed.
 Each component that exports actions to other components would own one or
 more command queues. When sending a command, the queue is specified by
 component and "subqueue" to allow components to manage multiple queues
 that are processed with different priorities.
 
-Settings are hashes representing the current configuration of each component.
+**Settings** are hashes representing the current configuration of each component.
 The settings for a single component can all be read atomically and written
 atomically, to avoid bugs where one component gets into an inconsistent state
 by reading settings when partially updates by another component. Note that
@@ -479,10 +481,13 @@ designs where settings consistency depends on updating multiple components at
 the same time would need to implement that separately, e.g. with some form of
 locking.
 
-Status are also hashes, but represent a component's current runtime state
+**Status** are also hashes, but represent a component's current runtime state
 instead of representing how a component has been configured. While settings
 are likely written by a single component, each component maintains its own
 status with any state info that is of interest to one or more other components.
+
+**State** is a single string value representing the currently active state of a
+component that incorporates a state machine.
 
 Event channels are an efficient way to broadcast events from one component to
 any others that might be interested (i.e. "subscribers). At the toplevel,

--- a/src/redis_ipc.c
+++ b/src/redis_ipc.c
@@ -101,6 +101,7 @@ static void stderr_debug(const char *format, ...)
 enum redis_ipc_type
 {
     RPC_TYPE_INVALID = 0,
+    RPC_TYPE_ACTIVE_STATE,
     RPC_TYPE_SETTING,
     RPC_TYPE_STATUS,
     RPC_TYPE_COMMAND,
@@ -112,6 +113,7 @@ enum redis_ipc_type
 const char *redis_ipc_type_names[] =
 {
     "INVALID",
+    "active_state",
     "settings",
     "status",
     "queues.commands",
@@ -148,6 +150,7 @@ static int ipc_path(char *buf, size_t buf_len, enum redis_ipc_type type,
 
     switch (type)
     {
+        case RPC_TYPE_ACTIVE_STATE:
         case RPC_TYPE_SETTING:
         case RPC_TYPE_STATUS:
         case RPC_TYPE_COMMAND:
@@ -1104,6 +1107,101 @@ const char * redis_ipc_read_status_field(const char *owner_component, const char
 redis_ipc_read_status_field_finish:
 
     return field_value;
+}
+
+static const char * redis_read_key(const char *key_path)
+{
+    struct redis_ipc_per_thread *thread_info = get_per_thread_info();
+    redisReply *reply = NULL;
+    const char *val = NULL;
+
+    // don't forget to free reply later
+    reply = redis_command("GET %s", key_path);
+
+    // extract value from reply object
+    //
+    // reply should be a string
+
+    if (reply == NULL)
+        goto redis_read_key_finish;
+    if (reply->type != REDIS_REPLY_STRING)
+        goto redis_read_key_finish;
+
+    val = strdup(reply->str);
+    if (stderr_debug_is_enabled()) fprintf(stderr, "(%s) %s='%s' [KEY]\n", thread_info->component, key_path, val);
+
+redis_read_key_finish:
+    if (reply != NULL)
+        freeReplyObject(reply);
+
+    return val;
+}
+
+int redis_write_key(const char *key_path, const char *key_value)
+{
+    redisReply *reply = NULL;
+    int ret = RIPC_FAIL;
+
+    // don't forget to free reply later
+    reply = redis_command("SET %s %s", key_path, key_value);
+
+    if (reply != NULL)
+    {
+        ret = RIPC_OK;
+        freeReplyObject(reply);
+    }
+
+    return ret;
+}
+
+int redis_ipc_write_active_state(const char *state)
+{
+    char state_key_path[RIPC_MAX_IPC_PATH_LEN];
+    struct redis_ipc_per_thread *thread_info = get_per_thread_info();
+    int ret = RIPC_FAIL;
+
+    // make sure successful init has been performed
+    if (thread_info == NULL)
+        goto redis_ipc_write_active_state_finish;
+
+    // calculate name of own state key
+    ret = ipc_path(state_key_path, sizeof(state_key_path),
+                   RPC_TYPE_ACTIVE_STATE, thread_info->component, NULL);
+    if (ret != RIPC_OK)
+        goto redis_ipc_write_active_state_finish;
+
+    // set value of state key
+    ret = redis_write_key(state_key_path, state);
+
+redis_ipc_write_active_state_finish:
+
+    return ret;
+}
+
+
+char * redis_ipc_read_active_state(const char *owner_component)
+{
+    char state_key_path[RIPC_MAX_IPC_PATH_LEN];
+    struct redis_ipc_per_thread *thread_info = get_per_thread_info();
+    const char *val = NULL;
+    int ret = RIPC_FAIL;
+
+    // make sure successful init has been performed
+    if (thread_info == NULL)
+        goto redis_ipc_read_active_state_finish;
+
+    // calculate name of state belonging to specified component
+    ret = ipc_path(state_key_path, sizeof(state_key_path),
+                   RPC_TYPE_ACTIVE_STATE, owner_component, NULL);
+    if (ret != RIPC_OK)
+        goto redis_ipc_read_active_state_finish;
+
+    // get value of state key
+    val = redis_read_key(state_key_path);
+
+redis_ipc_read_active_state_finish:
+
+    return val;
 }
 
 static int redis_publish(const char *channel_path, json_object *obj)

--- a/src/redis_ipc.h
+++ b/src/redis_ipc.h
@@ -188,6 +188,16 @@ int redis_ipc_write_status_field(const char *field_name, const char *field_value
 const char * redis_ipc_read_status_field(const char *owner_component, const char *field_name);
 
 
+// A component can only write its own state,
+// but it can read the state of any component.
+//
+// Each component can set a single string to indicate its currently active state;
+// more complicated runtime state may be maintained in 'status' instead.
+
+int redis_ipc_write_active_state(const char *state);
+char * redis_ipc_read_active_state(const char *owner_component);
+
+
 // Each component can only send event messages to its own event channel(s),
 // but can subscribe to any (or all) event channels.
 //

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -9,6 +9,7 @@ LIBREDISIPC = $(top_srcdir)/src/.libs/libredis_ipc.la
 BUILT_TESTS = command_result_test \
               json_test \
               multithread_test\
+              active_state_test \
               settings_status_test \
               pub_sub_test
 
@@ -28,6 +29,10 @@ json_test_LDFLAGS = -Wl,--hash-style=gnu -no-install
 multithread_test_SOURCES = multithread_test.c
 multithread_test_LDADD = -lhiredis -ljson-c $(LIBREDISIPC) -lpthread
 multithread_test_LDFLAGS = -Wl,--hash-style=gnu -no-install
+
+active_state_test_SOURCES = active_state_test.c
+active_state_test_LDADD = -lhiredis -ljson-c $(LIBREDISIPC) -lpthread
+active_state_test_LDFLAGS = -Wl,--hash-style=gnu -no-install
 
 pub_sub_test_SOURCES = pub_sub_test.c
 pub_sub_test_LDADD = -lhiredis -ljson-c $(LIBREDISIPC) -lpthread

--- a/test/active_state_test.c
+++ b/test/active_state_test.c
@@ -1,0 +1,43 @@
+#include <stdio.h>
+#include <unistd.h>
+#include "redis_ipc.h"
+
+int main(int argc, char **argv)
+{
+  char *write_state = NULL, *read_state = NULL;
+
+  redis_ipc_init("blackbox", "main");
+
+  write_state = "SQUEAKING";
+  redis_ipc_write_active_state(write_state);
+  read_state = redis_ipc_read_active_state("blackbox");
+  printf("wrote '%s', got back '%s'\n", write_state, read_state);
+  free(read_state);
+
+  write_state = "BOUNCING";
+  redis_ipc_write_active_state(write_state);
+  read_state = redis_ipc_read_active_state("blackbox");
+  printf("wrote '%s', got back '%s'\n", write_state, read_state);
+  free(read_state);
+
+  write_state = "SPLASHING";
+  redis_ipc_write_active_state(write_state);
+  read_state = redis_ipc_read_active_state("blackbox");
+  printf("wrote '%s', got back '%s'\n", write_state, read_state);
+  free(read_state);
+
+  read_state = redis_ipc_read_active_state("purplebox");
+  if (read_state == NULL)
+  {
+    printf("read NULL for non-existent state\n");
+  }
+  else
+  {
+    printf("read non-NULL '%s' for non-existent state??\n", read_state);
+    free(read_state);
+  }
+
+  redis_ipc_cleanup(getpid());
+
+  return 0;
+}


### PR DESCRIPTION
Each component can now publish its overall 'active_state', which is a single top-level value separate from its 'status' hash. This 'active_state' is intended for showing which state of a component's state machine is currently selected.

There is just one value being maintained for state, so if a component is complex enough to have substates the app will be responsible for encoding them together into a single string (e.g. concatenated to the primary state separated by delimiters).