### PR TITLE
fix thread link target and default coverage state

### DIFF
--- a/.github/workflows/debs.yml
+++ b/.github/workflows/debs.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   get_version:
     name: Get version info
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     defaults:
@@ -33,7 +33,7 @@ jobs:
 
   build_debs:
     name: ${{ matrix.name }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     needs: [get_version]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,13 +32,6 @@ set(CMAKE_C_STANDARD 17)
 set(CMAKE_C_EXTENSIONS ON)
 set(CMAKE_DEBUG_POSTFIX d)
 
-if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE
-        "RelWithDebInfo"
-        CACHE STRING "Default build type: RelWithDebInfo" FORCE
-    )
-endif()
-
 include(CMakeParseArguments)
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
@@ -64,7 +57,7 @@ endif()
 
 option(BUILD_SHARED_LIBS "build shared libraries" ON)
 option(BUILD_STATIC_LIBS "Build static libraries" OFF)
-option(RIPC_BUILD_TESTING "build and run tests" OFF)
+option(RIPC_BUILD_TESTING "build and run tests" ON)
 option(WITH_COVERAGE "build with test coverage but no optimization" OFF)
 option(RIPC_DISABLE_SOCK_TESTS "disable tests requiring redis socket" OFF)
 
@@ -172,6 +165,14 @@ target_compile_definitions(redis_ipc PRIVATE VERSION_INFO=${PACKAGE_VERSION})
 set_target_properties(
     redis_ipc PROPERTIES VERSION ${RIPC_SONAME} SOVERSION ${LIBRARY_SOVERSION}
 )
+
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE
+        "Debug"
+        CACHE STRING "Default build type: Debug" FORCE
+    )
+endif()
+message("* Current build type is : ${CMAKE_BUILD_TYPE}")
 
 if(RIPC_BUILD_TESTING)
     enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,16 +65,12 @@ endif()
 option(BUILD_SHARED_LIBS "build shared libraries" ON)
 option(BUILD_STATIC_LIBS "Build static libraries" OFF)
 option(RIPC_BUILD_TESTING "build and run tests" OFF)
+option(WITH_COVERAGE "build with test coverage but no optimization" OFF)
 option(RIPC_DISABLE_SOCK_TESTS "disable tests requiring redis socket" OFF)
 
 set(RIPC_RUNTIME_DIR
     ""
     CACHE PATH "path to directory containing redis server socket"
-)
-
-set(WITH_COVERAGE
-    ""
-    CACHE PATH "build with test coverage enabled"
 )
 
 set(INSTALL_PKGCONFIG_DIR
@@ -149,7 +145,8 @@ elseif(UNIX)
     set(CMAKE_THREAD_PREFER_PTHREAD ON)
     set(THREADS_PREFER_PTHREAD_FLAG ON)
     find_package(Threads REQUIRED)
-    list(APPEND EXTRA_TARGET_LINK_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
+    # link to the proper target, NOT a variable or hard-coded flag
+    list(APPEND EXTRA_TARGET_LINK_LIBRARIES Threads::Threads)
 endif()
 
 include_directories(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 
 option(BUILD_SHARED_LIBS "build shared libraries" ON)
 option(BUILD_STATIC_LIBS "Build static libraries" OFF)
-option(RIPC_BUILD_TESTING "build and run tests" ON)
+option(RIPC_BUILD_TESTING "build and run tests" OFF)
+option(COVERAGE_BUILD "Enable code coverage" OFF)
 option(WITH_COVERAGE "build with test coverage but no optimization" OFF)
 option(RIPC_DISABLE_SOCK_TESTS "disable tests requiring redis socket" OFF)
 

--- a/cmake/TestCoverage.cmake
+++ b/cmake/TestCoverage.cmake
@@ -1,7 +1,8 @@
 set(CMAKE_C_FLAGS "-g -O0 --coverage")
 set(CMAKE_CXX_FLAGS "-g -O0 --coverage")
-set(CMAKE_EXE_LINKER_FLAGS "--coverage")
-set(CMAKE_SHARED_LINKER_FLAGS "--coverage")
+# note coverage flag is already in linker args
+set(CMAKE_EXE_LINKER_FLAGS "")
+set(CMAKE_SHARED_LINKER_FLAGS "")
 
 set(COVERAGE_OUTPUT_DIR "${CMAKE_SOURCE_DIR}/coverage")
 set(TRACEFILE "${CMAKE_SOURCE_DIR}/coverage.info")

--- a/cmake/coverage.cmake
+++ b/cmake/coverage.cmake
@@ -20,13 +20,13 @@ if(COVERAGE_BUILD)
     find_program(
         LLVM_COV_PATH
         NAMES llvm-cov
-        HINTS ${LLVM_DIRECTORY}
+        HINTS ${LLVM_DIRECTORY} llvm-${LLVM_DIRECTORY}
         PATH_SUFFIXES bin
     )
     find_program(
         LLVM_PROFDATA_PATH
         NAMES llvm-profdata
-        HINTS ${LLVM_DIRECTORY}
+        HINTS ${LLVM_DIRECTORY} llvm-${LLVM_DIRECTORY}
         PATH_SUFFIXES bin
     )
 

--- a/cmake/coverage.cmake
+++ b/cmake/coverage.cmake
@@ -1,4 +1,3 @@
-option(COVERAGE_BUILD "Enable code coverage" OFF)
 option(COVERAGE_TEXT "Show text summary of the coverage" ON)
 option(COVERAGE_LCOV "Export coverage data in lcov trace file" ON)
 option(COVERAGE_HTML "Detailed html report of the coverage" OFF)

--- a/debian/rules
+++ b/debian/rules
@@ -17,7 +17,7 @@ multiarch_path = $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 override_dh_auto_configure:
 	dh_auto_configure -- -DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DBUILD_STATIC_LIBS=ON \
-		-DBUILD_TESTING=OFF
+		-DRIPC_BUILD_TESTING=OFF
 
 override_dh_auto_clean:
 	rm -rf $(CURDIR)/build

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,9 @@ setenv =
     clang: CC = {env:CC:clang}
     clang: CXX = {env:CXX:clang++}
     bionic: ENV_RIPC_RUNTIME_DIR = {env:ENV_RIPC_RUNTIME_DIR:{envtmpdir}}
-    LLVM_VER_DIR = {env:LLVM_VER_DIR:llvm-15}
+    LLVM_VER_DIR = {env:LLVM_VER_DIR:20}
+    BUILD_TYPE = {env:BUILD_TYPE:Debug}
+    WITH_COVERAGE = {env:WITH_COVERAGE:1}
 
 allowlist_externals =
     {tests,clang,ctest,bionic,lint,grind,clean}: bash
@@ -69,7 +71,7 @@ commands =
     bionic: bash -c 'RIPC_RUNTIME_DIR=$ENV_RIPC_RUNTIME_DIR {toxinidir}/scripts/run_redis.sh status'
     bionic: bash -c 'RIPC_SERVER_PATH=$ENV_RIPC_RUNTIME_DIR/socket make cov'
     clang: bash -c 'cmake -G {posargs:"Unix Makefiles"} -DRIPC_BUILD_TESTING=ON -DCOVERAGE_BUILD=ON -DCOVERAGE_HTML=ON ..'
-    tests: bash -c 'cmake -G {posargs:"Unix Makefiles"} -DWITH_COVERAGE=1 -DCMAKE_BUILD_TYPE=Debug ..'
+    tests: bash -c 'cmake -G {posargs:"Unix Makefiles"} -DWITH_COVERAGE=${WITH_COVERAGE} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..'
     grind: bash -c 'cmake -DRIPC_BUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug ..'
     {tests,clang,grind}: bash -c 'cmake --build . -j $(nproc)'
     tests: bash -c 'ctest -V --test-dir ./'
@@ -80,7 +82,7 @@ commands =
     bionic: gcovr -r {toxinidir} --xml-pretty -o coverage.xml .
     bionic: gcovr -r {toxinidir} --html --html-details -o {toxinidir}/coverage/coverage.html .
     {bionic}: bash -c 'RIPC_RUNTIME_DIR=$ENV_RIPC_RUNTIME_DIR {toxinidir}/scripts/run_redis.sh stop'
-    ctest: bash -c 'ctest --build-generator {posargs:"Ninja"} --build-and-test . build --build-options -DWITH_COVERAGE=ON -DCMAKE_BUILD_TYPE=Debug --test-command ctest --rerun-failed --output-on-failure -V'
+    ctest: bash -c 'ctest --build-generator {posargs:"Ninja"} --build-and-test . build --build-options -DWITH_COVERAGE=${WITH_COVERAGE} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} --test-command ctest --rerun-failed --output-on-failure -V'
     ctest: gcovr --gcov-ignore-parse-errors=negative_hits.warn -s --txt-metric branch build/
     cover: gcovr --xml-pretty -o coverage.xml build/
     # runtime assertion error without || true =>  (SIGSEGV)) (exited with code -11)

--- a/tox.ini
+++ b/tox.ini
@@ -34,10 +34,12 @@ passenv =
 setenv =
     clang: CC = {env:CC:clang}
     clang: CXX = {env:CXX:clang++}
+    {tests,bionic,ctest,grind}: CC = {env:CC:gcc}
+    {tests,bionic,ctest,grind}: CXX = {env:CXX:g++}
     bionic: ENV_RIPC_RUNTIME_DIR = {env:ENV_RIPC_RUNTIME_DIR:{envtmpdir}}
     LLVM_VER_DIR = {env:LLVM_VER_DIR:20}
     BUILD_TYPE = {env:BUILD_TYPE:Debug}
-    WITH_COVERAGE = {env:WITH_COVERAGE:1}
+    WITH_COVERAGE = {env:WITH_COVERAGE:OFF}
 
 allowlist_externals =
     {tests,clang,ctest,bionic,lint,grind,clean}: bash
@@ -70,7 +72,7 @@ commands =
     bionic: bash -c 'RIPC_RUNTIME_DIR=$ENV_RIPC_RUNTIME_DIR {toxinidir}/scripts/run_redis.sh start > /dev/null'
     bionic: bash -c 'RIPC_RUNTIME_DIR=$ENV_RIPC_RUNTIME_DIR {toxinidir}/scripts/run_redis.sh status'
     bionic: bash -c 'RIPC_SERVER_PATH=$ENV_RIPC_RUNTIME_DIR/socket make cov'
-    clang: bash -c 'cmake -G {posargs:"Unix Makefiles"} -DRIPC_BUILD_TESTING=ON -DCOVERAGE_BUILD=ON -DCOVERAGE_HTML=ON ..'
+    clang: bash -c 'cmake -G {posargs:"Unix Makefiles"} -DRIPC_BUILD_TESTING=ON -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCOVERAGE_BUILD=ON -DCOVERAGE_HTML=ON ..'
     tests: bash -c 'cmake -G {posargs:"Unix Makefiles"} -DWITH_COVERAGE=${WITH_COVERAGE} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..'
     grind: bash -c 'cmake -DRIPC_BUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug ..'
     {tests,clang,grind}: bash -c 'cmake --build . -j $(nproc)'
@@ -115,6 +117,8 @@ passenv =
     PIP_DOWNLOAD_CACHE
 
 setenv =
+    {auto,dist}: CC = {env:CC:gcc}
+    {auto,dist}: CXX = {env:CXX:g++}
     auto: ENV_RIPC_RUNTIME_DIR = {env:ENV_RIPC_RUNTIME_DIR:{envtmpdir}}
 
 allowlist_externals =


### PR DESCRIPTION
* current cmake guidance for threads says link to imported target after using find_package
* llvm coverage target forces -O0 but ends up first in command line so gets overridden by build_type opt flags so for now we default to OFF for llvm source coverage
* this means you should only enable one at a time, either source coverage or Release/IPO but not both